### PR TITLE
feat(skills): dev-kickoff → pr-iterate の worktree 連携改善

### DIFF
--- a/claude-code/skills/dev-kickoff/SKILL.md
+++ b/claude-code/skills/dev-kickoff/SKILL.md
@@ -37,6 +37,15 @@ After completing a phase:
 ~/.claude/skills/dev-kickoff/scripts/update-phase.sh <phase> done --result "Summary" --worktree $PATH
 ```
 
+After PR creation (phase 6_pr), record PR info for pr-iterate handoff:
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 6_pr done \
+  --result "PR created" \
+  --pr-number 123 \
+  --pr-url "https://github.com/org/repo/pull/123" \
+  --worktree $PATH
+```
+
 On failure:
 ```bash
 ~/.claude/skills/dev-kickoff/scripts/update-phase.sh <phase> failed --error "Error message" --worktree $PATH
@@ -51,8 +60,10 @@ On failure:
 ## Workflow
 
 ```
-git-prepare.sh → init-kickoff.sh → dev-issue-analyze → dev-implement → dev-validate → git-commit → git-pr
+git-prepare.sh → init-kickoff.sh → dev-issue-analyze → dev-implement → dev-validate → git-commit → git-pr → pr-iterate
 ```
+
+After PR creation, kickoff.json is updated with PR info and `next_action: "pr-iterate"`. The pr-iterate skill automatically detects the worktree from kickoff.json.
 
 ## Phase Execution
 
@@ -118,7 +129,23 @@ ls $WORKTREE_PATH/.env || echo "ERROR: .env not linked - script was not used"
 ```
 $WORKTREE/
 ├── .claude/
-│   └── kickoff.json    # Machine-readable state
+│   ├── kickoff.json    # Machine-readable state
+│   └── iterate.json    # pr-iterate state (created after PR)
 └── docs/
     └── STATE.md        # Human-readable summary (optional)
+```
+
+## kickoff.json Schema (with PR info)
+
+```json
+{
+  "issue": 123,
+  "worktree": "/path/to/worktree",
+  "pr": {
+    "number": 456,
+    "url": "https://github.com/org/repo/pull/456",
+    "created_at": "2026-01-28T10:00:00Z"
+  },
+  "next_action": "pr-iterate"
+}
 ```

--- a/claude-code/skills/pr-iterate/SKILL.md
+++ b/claude-code/skills/pr-iterate/SKILL.md
@@ -24,11 +24,22 @@ allowed-tools:
 
 ## State Persistence
 
-State is persisted in `.claude/iterate.json` for recovery after auto-compact.
+State is persisted in `$WORKTREE/.claude/iterate.json` for recovery after auto-compact.
+
+### Worktree Auto-Detection
+
+The scripts automatically detect the worktree path using this priority:
+1. `--worktree` explicit argument
+2. `kickoff.json` auto-detect (reads `worktree` field from `.claude/kickoff.json`)
+3. Current git root (fallback)
 
 ### Initialize State
 
 ```bash
+# Explicit worktree
+~/.claude/skills/pr-iterate/scripts/init-iterate.sh $PR [--max-iterations N] --worktree $PATH
+
+# Auto-detect from kickoff.json (when running from worktree or main repo with kickoff.json)
 ~/.claude/skills/pr-iterate/scripts/init-iterate.sh $PR [--max-iterations N]
 ```
 
@@ -80,11 +91,25 @@ State is persisted in `.claude/iterate.json` for recovery after auto-compact.
 ## State File Location
 
 ```
-$REPO/
+$WORKTREE/
 ├── .claude/
-│   └── iterate.json    # Machine-readable state
+│   ├── kickoff.json    # From dev-kickoff (contains worktree path, PR info)
+│   └── iterate.json    # pr-iterate state
 └── docs/
     └── STATE.md        # Human-readable summary (auto-generated)
+```
+
+## iterate.json Schema
+
+```json
+{
+  "pr_number": 456,
+  "pr_url": "https://github.com/org/repo/pull/456",
+  "worktree_path": "/path/to/worktree",
+  "current_iteration": 1,
+  "max_iterations": 10,
+  "status": "in_progress"
+}
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary

dev-kickoff で PR 作成後、pr-iterate が worktree を自動検出できるよう改善しました。

### 変更内容

- **update-phase.sh**: `--pr-url`, `--pr-number` オプション追加
  - Phase 6_pr 完了時に PR 情報を kickoff.json に記録
  - `next_action: "pr-iterate"` を自動設定
- **init-iterate.sh**: worktree 自動検出ロジック追加
  - 優先順位: `--worktree` 明示 → `kickoff.json` から検出 → 現在のディレクトリ
  - `worktree_path` を iterate.json に保存
- **record-iteration.sh**: kickoff.json からの worktree 検出フォールバック追加
- **SKILL.md**: 新しいワークフローと状態ファイルスキーマを文書化

### ワークフロー変更

**Before:**
```
dev-kickoff → PR作成 → 終了（元のディレクトリ）
ユーザーが手動で /pr-iterate
```

**After:**
```
dev-kickoff → PR作成 → kickoff.json に PR 情報記録 → pr-iterate 自動開始可能
                                                    ↓
                                               kickoff.json から worktree_path 検出
                                                    ↓
                                               worktree 内で iterate.json 作成・作業継続
```

## Test Plan

- [x] update-phase.sh の PR オプション動作確認
- [x] init-iterate.sh の worktree 自動検出ロジック検証
- [x] 全スクリプトの構文チェック

Closes #11