### PR TITLE
✨ feat: clawdbot設定のdotfiles管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,19 @@ claude-code/.superclaude-metadata.json
 claude-code/skills/**/.env
 claude-code/skills/**/__pycache__/
 
+# Clawdbot - sensitive and runtime data
+clawdbot/.env
+clawdbot/credentials/
+clawdbot/identity/
+clawdbot/memory/
+clawdbot/logs/
+clawdbot/devices/
+clawdbot/agents/*/sessions/
+clawdbot/*.bak
+clawdbot/update-check.json
+clawdbot/exec-approvals.json
+clawdbot/cron/state.json
+
 # Nix
 result
 result-*

--- a/clawdbot/.gitignore
+++ b/clawdbot/.gitignore
@@ -1,0 +1,23 @@
+# Secrets
+.env
+credentials/
+identity/
+
+# Runtime generated
+memory/
+logs/
+devices/
+
+# Backups
+*.bak
+clawdbot.json.bak
+
+# Sessions
+agents/*/sessions/
+
+# State files
+update-check.json
+exec-approvals.json
+
+# Cron state
+cron/state.json

--- a/clawdbot/agents/.gitkeep
+++ b/clawdbot/agents/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder to preserve directory structure
+# Agent configurations will be stored here

--- a/clawdbot/clawdbot.json
+++ b/clawdbot/clawdbot.json
@@ -1,0 +1,139 @@
+{
+  "meta": {
+    "lastTouchedVersion": "2026.1.24-3",
+    "lastTouchedAt": "2026-01-27T08:18:44.444Z"
+  },
+  "env": {
+    "shellEnv": {
+      "enabled": true
+    }
+  },
+  "wizard": {
+    "lastRunAt": "2026-01-27T08:18:44.426Z",
+    "lastRunVersion": "2026.1.24-3",
+    "lastRunCommand": "doctor",
+    "lastRunMode": "local"
+  },
+  "update": {
+    "channel": "stable",
+    "checkOnStart": true
+  },
+  "auth": {
+    "profiles": {
+      "minimax:default": {
+        "provider": "minimax",
+        "mode": "api_key"
+      },
+      "google:default": {
+        "provider": "google",
+        "mode": "api_key"
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {}
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "google/gemini-3-flash-preview",
+        "fallbacks": [
+          "google/gemini-3-pro-preview"
+        ]
+      },
+      "models": {
+        "minimax/MiniMax-M2.1": {
+          "alias": "Minimax"
+        },
+        "google/gemini-3-flash-preview": {
+          "alias": "gemini-flash"
+        },
+        "google/gemini-3-pro-preview": {
+          "alias": "gemini"
+        }
+      },
+      "workspace": "${HOME}/clawd",
+      "contextPruning": {
+        "mode": "cache-ttl",
+        "ttl": "1h"
+      },
+      "compaction": {
+        "mode": "safeguard"
+      },
+      "heartbeat": {
+        "every": "30m"
+      },
+      "maxConcurrent": 4,
+      "subagents": {
+        "maxConcurrent": 8
+      }
+    }
+  },
+  "messages": {
+    "ackReactionScope": "group-mentions"
+  },
+  "commands": {
+    "native": "auto",
+    "nativeSkills": "auto"
+  },
+  "channels": {
+    "slack": {
+      "mode": "socket",
+      "webhookPath": "/slack/events",
+      "enabled": true,
+      "botToken": "${SLACK_BOT_TOKEN}",
+      "appToken": "${SLACK_APP_TOKEN}",
+      "userTokenReadOnly": false,
+      "groupPolicy": "allowlist",
+      "channels": {
+        "#general": {
+          "allow": true
+        },
+        "#random": {
+          "allow": true
+        },
+        "0-colle": {
+          "allow": true
+        },
+        "kazoeru-kun": {
+          "allow": true
+        },
+        "税務相談用": {
+          "allow": true
+        },
+        "shift-bud": {
+          "allow": true
+        },
+        "test": {
+          "allow": true
+        }
+      }
+    }
+  },
+  "gateway": {
+    "port": 18789,
+    "mode": "local",
+    "bind": "loopback",
+    "auth": {
+      "mode": "token",
+      "token": "${CLAWDBOT_GATEWAY_TOKEN}"
+    },
+    "tailscale": {
+      "mode": "off",
+      "resetOnExit": false
+    }
+  },
+  "skills": {
+    "install": {
+      "nodeManager": "pnpm"
+    }
+  },
+  "plugins": {
+    "entries": {
+      "slack": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/clawdbot/cron/jobs.json
+++ b/clawdbot/cron/jobs.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://molt.bot/schemas/cron-jobs.json",
+  "jobs": []
+}

--- a/home-manager/home/file/clawdbot.env.template
+++ b/home-manager/home/file/clawdbot.env.template
@@ -1,0 +1,13 @@
+# Clawdbot Environment Variables
+# Copy this file to ~/.clawdbot/.env and fill in the values
+# These values are used by clawdbot for environment variable expansion
+
+# Slack Bot Token (xoxb-...)
+SLACK_BOT_TOKEN=
+
+# Slack App Token (xapp-...)
+SLACK_APP_TOKEN=
+
+# Gateway authentication token
+# Generate with: openssl rand -hex 24
+CLAWDBOT_GATEWAY_TOKEN=


### PR DESCRIPTION
## 概要

clawdbot設定ファイル(`~/.clawdbot/`)をdotfilesリポジトリで管理可能にする。

Closes #17

## 変更内容

- `clawdbot/clawdbot.json`: 機密情報を環境変数展開(`${VAR}`)に置換
- `clawdbot/.gitignore`: ランタイムファイル・機密情報の除外設定
- `home-manager/home/default.nix`: `setupClawdbot` activation hook追加
- `home-manager/home/file/clawdbot.env.template`: 環境変数テンプレート
- `.gitignore`: clawdbot関連の除外パターン追加

## 環境変数

| 項目 | 環境変数 |
|------|----------|
| Slack Bot Token | `${SLACK_BOT_TOKEN}` |
| Slack App Token | `${SLACK_APP_TOKEN}` |
| Gateway Token | `${CLAWDBOT_GATEWAY_TOKEN}` |
| Workspace Path | `${HOME}/clawd` |

## セットアップ手順

1. `nix run .#update` 実行（シンボリックリンク作成）
2. バックアップから `.env` ファイルをコピー、または新規作成:
   ```bash
   cp ~/.clawdbot.backup.*/\.env ~/.clawdbot/.env
   # または
   cp ~/.clawdbot/.env.template ~/.clawdbot/.env
   # シークレットを記入
   ```
3. clawdbot再起動

## テスト計画

- [x] Nix flake check 通過
- [x] JSON構文検証
- [ ] `nix run .#update` でシンボリックリンク作成確認
- [ ] clawdbot動作確認