### PR TITLE
fix(skills): dev-flow commit後停止問題の修正 + 2026 Best Practice準拠

### DIFF
--- a/claude-code/skills/dev-flow/SKILL.md
+++ b/claude-code/skills/dev-flow/SKILL.md
@@ -12,14 +12,55 @@ allowed-tools:
 
 # Dev Flow
 
+End-to-end development automation from issue to merged PR.
+
+## ⚠️ CRITICAL: Complete All Phases
+
+**This workflow has 3 steps. DO NOT EXIT until pr-iterate completes.**
+
+| Step | Action | Complete When |
+|------|--------|---------------|
+| 1 | `Skill: dev-kickoff` | PR URL available |
+| 2 | `gh pr view --json url` | URL captured |
+| 3 | `Skill: pr-iterate` | PR merged or max iterations |
+
 ## Usage
 
 ```
-/dev-flow <issue> [--strategy tdd] [--depth comprehensive] [--base dev] [--max-iterations 10]
+/dev-flow <issue> [--strategy tdd] [--depth comprehensive] [--base main] [--max-iterations 10]
 ```
 
-## Workflow
+## Workflow Checklist
 
-1. Skill: `dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE`
-2. Get PR URL: `gh pr view --json url --jq .url`
-3. Skill: `pr-iterate $PR --max-iterations $MAX`
+Execute in order. Mark each complete before proceeding:
+
+```
+[ ] Step 1: Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE
+[ ] Step 2: PR_URL=$(gh pr view --json url --jq .url)
+[ ] Step 3: Skill: pr-iterate $PR_URL --max-iterations $MAX
+```
+
+## Completion Conditions
+
+| Condition | Action |
+|-----------|--------|
+| pr-iterate completes | ✅ Workflow complete |
+| PR merged | ✅ Workflow complete |
+| Max iterations reached | ⚠️ Report status, user decides |
+| Any step fails | ❌ Report error, do not proceed |
+
+## State Recovery
+
+After auto-compact, check worktree state:
+
+```bash
+~/.claude/skills/dev-flow/scripts/flow-status.sh --worktree $WORKTREE
+```
+
+Output tells you the next action.
+
+## References
+
+- [Workflow Details](references/workflow-detail.md) - Full phase descriptions
+- [dev-kickoff](../dev-kickoff/SKILL.md) - Orchestrator skill
+- [pr-iterate](../pr-iterate/SKILL.md) - PR iteration skill

--- a/claude-code/skills/dev-flow/references/workflow-detail.md
+++ b/claude-code/skills/dev-flow/references/workflow-detail.md
@@ -1,0 +1,138 @@
+# Dev Flow - Workflow Details
+
+Detailed documentation for the dev-flow skill workflow.
+
+## Architecture
+
+```
+dev-flow (wrapper)
+    │
+    ├─→ Step 1: dev-kickoff (orchestrator)
+    │       ├─→ Phase 1: git-prepare.sh (worktree)
+    │       ├─→ Phase 2: dev-issue-analyze (exploration)
+    │       ├─→ Phase 3: dev-implement (coding)
+    │       ├─→ Phase 4: dev-validate (testing)
+    │       ├─→ Phase 5: git-commit (commit)
+    │       └─→ Phase 6: git-pr (PR creation)
+    │
+    ├─→ Step 2: Get PR URL
+    │       └─→ gh pr view --json url --jq .url
+    │
+    └─→ Step 3: pr-iterate (review loop)
+            └─→ Review → Fix → Push → Repeat
+```
+
+## State Flow
+
+### State Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| kickoff.json | `$WORKTREE/.claude/kickoff.json` | Phase tracking, PR info |
+| iterate.json | `$WORKTREE/.claude/iterate.json` | Iteration count, review status |
+
+### Phase Progression
+
+```
+1_prepare → 2_analyze → 3_implement → 4_validate → 5_commit → 6_pr → completed
+```
+
+Each phase transition is recorded by `update-phase.sh` which:
+1. Sets current phase status to "done"
+2. Advances `current_phase` to next
+3. Records timestamp and result
+
+## Step 1: dev-kickoff
+
+The orchestrator handles 6 phases internally. See [dev-kickoff/SKILL.md](../../dev-kickoff/SKILL.md).
+
+### Completion Signal
+
+When Phase 6 (PR creation) completes, kickoff.json is updated with:
+- `pr.number`: PR number
+- `pr.url`: Full PR URL
+- `next_action`: "pr-iterate"
+- `current_phase`: "completed"
+
+## Step 2: Get PR URL
+
+Simple extraction from GitHub CLI:
+
+```bash
+gh pr view --json url --jq .url
+```
+
+Alternative via kickoff.json:
+```bash
+jq -r '.pr.url' $WORKTREE/.claude/kickoff.json
+```
+
+## Step 3: pr-iterate
+
+Handles the review-fix-push loop. See [pr-iterate/SKILL.md](../../pr-iterate/SKILL.md).
+
+### Input Sources
+
+pr-iterate can receive PR reference from:
+1. Direct argument: `pr-iterate https://github.com/org/repo/pull/123`
+2. kickoff.json auto-detection (checks `.next_action == "pr-iterate"`)
+
+## Recovery After Auto-Compact
+
+When Claude auto-compacts, context is lost. To recover:
+
+1. **Identify Worktree**
+   ```bash
+   # List recent worktrees
+   ls -lt ~/ghq/github.com/*/*-worktrees/
+   ```
+
+2. **Check State**
+   ```bash
+   ~/.claude/skills/dev-flow/scripts/flow-status.sh --worktree $PATH
+   ```
+
+3. **Resume**
+   - Follow `next_action` from output
+   - State file preserves all progress
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Phase fails in kickoff | kickoff.json records error, stops |
+| PR creation fails | Manual `gh pr create`, then update state |
+| pr-iterate fails | Check iterate.json, retry or manual fix |
+| State file missing | Cannot recover, start fresh |
+
+## Debugging
+
+Check each state file:
+
+```bash
+# Kickoff state
+cat $WORKTREE/.claude/kickoff.json | jq '.'
+
+# Current phase
+cat $WORKTREE/.claude/kickoff.json | jq '.current_phase, .phases'
+
+# PR info
+cat $WORKTREE/.claude/kickoff.json | jq '.pr'
+```
+
+## Integration Points
+
+### With dev-kickoff
+- dev-flow calls dev-kickoff as first step
+- Waits for PR URL to be available
+- kickoff.json is the handoff point
+
+### With pr-iterate
+- dev-flow extracts PR URL from kickoff or gh CLI
+- Passes URL to pr-iterate
+- pr-iterate creates its own iterate.json
+
+### With GitHub CLI
+- `gh pr view` for PR status
+- `gh pr checks` for CI status
+- `gh pr merge` when ready

--- a/claude-code/skills/dev-flow/scripts/flow-status.sh
+++ b/claude-code/skills/dev-flow/scripts/flow-status.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# flow-status.sh - Check dev-flow state and determine next action
+# Usage: flow-status.sh [--worktree PATH]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        -*)
+            die_json "Unknown option: $1" 1
+            ;;
+        *)
+            if [[ -z "$WORKTREE" ]]; then
+                WORKTREE="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Find state file
+if [[ -n "$WORKTREE" ]]; then
+    [[ -d "$WORKTREE" ]] || die_json "Worktree path does not exist: $WORKTREE" 1
+    WORKTREE=$(cd "$WORKTREE" && pwd) || die_json "Cannot resolve worktree path" 1
+    STATE_FILE="$WORKTREE/.claude/kickoff.json"
+else
+    # Try current git root
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -n "$GIT_ROOT" && -f "$GIT_ROOT/.claude/kickoff.json" ]]; then
+        STATE_FILE="$GIT_ROOT/.claude/kickoff.json"
+        WORKTREE="$GIT_ROOT"
+    else
+        die_json "State file not found. Use --worktree or run from worktree directory." 1
+    fi
+fi
+
+[[ -f "$STATE_FILE" ]] || die_json "State file not found: $STATE_FILE" 1
+
+# Read state
+CURRENT_PHASE=$(jq -r '.current_phase // "unknown"' "$STATE_FILE")
+ISSUE=$(jq -r '.issue // "unknown"' "$STATE_FILE")
+PR_NUMBER=$(jq -r '.pr.number // ""' "$STATE_FILE")
+PR_URL=$(jq -r '.pr.url // ""' "$STATE_FILE")
+NEXT_ACTION=$(jq -r '.next_action // ""' "$STATE_FILE")
+BASE_BRANCH=$(jq -r '.base_branch // "main"' "$STATE_FILE")
+STRATEGY=$(jq -r '.config.strategy // "tdd"' "$STATE_FILE")
+DEPTH=$(jq -r '.config.depth // "standard"' "$STATE_FILE")
+LANG=$(jq -r '.config.lang // "ja"' "$STATE_FILE")
+
+# Determine dev-flow step based on kickoff state
+determine_flow_step() {
+    case "$CURRENT_PHASE" in
+        1_prepare|2_analyze|3_implement|4_validate|5_commit)
+            echo "step_1_kickoff"
+            ;;
+        6_pr)
+            # Check if PR was created
+            if [[ -n "$PR_NUMBER" ]]; then
+                echo "step_3_iterate"
+            else
+                echo "step_1_kickoff"
+            fi
+            ;;
+        completed)
+            if [[ -n "$PR_NUMBER" ]]; then
+                echo "step_3_iterate"
+            else
+                echo "completed"
+            fi
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
+FLOW_STEP=$(determine_flow_step)
+
+# Determine next action command
+case "$FLOW_STEP" in
+    step_1_kickoff)
+        NEXT_CMD="Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE_BRANCH"
+        STATUS="kickoff_in_progress"
+        ;;
+    step_3_iterate)
+        if [[ -n "$PR_URL" ]]; then
+            NEXT_CMD="Skill: pr-iterate $PR_URL"
+        else
+            NEXT_CMD="Skill: pr-iterate $PR_NUMBER"
+        fi
+        STATUS="ready_for_iterate"
+        ;;
+    completed)
+        NEXT_CMD=""
+        STATUS="workflow_complete"
+        ;;
+    *)
+        NEXT_CMD=""
+        STATUS="unknown_state"
+        ;;
+esac
+
+# Output JSON
+jq -n \
+    --arg status "$STATUS" \
+    --arg flow_step "$FLOW_STEP" \
+    --arg current_phase "$CURRENT_PHASE" \
+    --argjson issue "$ISSUE" \
+    --arg worktree "$WORKTREE" \
+    --arg pr_number "${PR_NUMBER:-null}" \
+    --arg pr_url "${PR_URL:-null}" \
+    --arg next_cmd "$NEXT_CMD" \
+    '{
+        status: $status,
+        flow_step: $flow_step,
+        kickoff_phase: $current_phase,
+        issue: $issue,
+        worktree: $worktree,
+        pr: (if $pr_number != "null" and $pr_number != "" then { number: ($pr_number | tonumber), url: $pr_url } else null end),
+        next_action: $next_cmd
+    }'

--- a/claude-code/skills/dev-kickoff/SKILL.md
+++ b/claude-code/skills/dev-kickoff/SKILL.md
@@ -3,7 +3,7 @@ name: dev-kickoff
 description: |
   End-to-end feature development orchestrator using git worktree. Coordinates git-prepare, issue-analyze, implement, validate, commit, and create-pr skills.
   Use when: starting new feature development from GitHub issue, full development cycle automation with isolated worktree.
-  Accepts args: <issue-number> [--strategy tdd|bdd|ddd] [--depth minimal|standard|comprehensive] [--base <branch>] [--lang ja|en] [--env-mode hardlink|symlink|copy|none] [--skip-pr]
+  Accepts args: <issue-number> [--strategy tdd|bdd|ddd] [--depth minimal|standard|comprehensive] [--base <branch>] [--lang ja|en] [--env-mode hardlink|symlink|copy|none]
 allowed-tools:
   - Bash
   - TodoWrite
@@ -13,95 +13,76 @@ allowed-tools:
 
 Orchestrate complete feature development cycle from issue to PR.
 
-## State Persistence
+## ⚠️ CRITICAL: Complete All 6 Phases
 
-State is persisted in `$WORKTREE/.claude/kickoff.json` for recovery after auto-compact.
+**DO NOT EXIT until Phase 6 (PR creation) completes and pr-iterate is called.**
 
-### Initialize State
+| Phase | Action | Complete When |
+|-------|--------|---------------|
+| 1 | Worktree creation | Path exists, .env verified |
+| 2 | Issue analysis | Requirements understood |
+| 3 | Implementation | Code written |
+| 4 | Validation | Tests pass |
+| 5 | Commit | Changes committed |
+| 6 | PR creation | PR URL available |
 
-After Phase 1 (worktree creation), run:
+After Phase 6: Call `Skill: pr-iterate $PR_URL` to complete the workflow.
+
+## Phase Checklist
+
+```
+[ ] Phase 1: git-prepare.sh → init-kickoff.sh
+[ ] Phase 2: Skill: dev-issue-analyze
+[ ] Phase 3: Skill: dev-implement
+[ ] Phase 4: Skill: dev-validate --fix
+[ ] Phase 5: Skill: git-commit --all
+[ ] Phase 6: Skill: git-pr → pr-iterate
+```
+
+## State Management
+
+State persisted in `$WORKTREE/.claude/kickoff.json` for recovery.
+
+### Initialize (After Phase 1)
+
 ```bash
-~/.claude/skills/dev-kickoff/scripts/init-kickoff.sh $ISSUE $BRANCH $WORKTREE_PATH \
+~/.claude/skills/dev-kickoff/scripts/init-kickoff.sh $ISSUE $BRANCH $WORKTREE \
   --base $BASE --strategy $STRATEGY --depth $DEPTH --lang $LANG --env-mode $ENV_MODE
 ```
 
 ### Update Phase Status
 
-Before starting a phase:
 ```bash
+# Start phase
 ~/.claude/skills/dev-kickoff/scripts/update-phase.sh <phase> in_progress --worktree $PATH
-```
 
-After completing a phase:
-```bash
+# Complete phase
 ~/.claude/skills/dev-kickoff/scripts/update-phase.sh <phase> done --result "Summary" --worktree $PATH
-```
 
-After PR creation (phase 6_pr), record PR info for pr-iterate handoff:
-```bash
+# After PR creation (Phase 6)
 ~/.claude/skills/dev-kickoff/scripts/update-phase.sh 6_pr done \
-  --result "PR created" \
-  --pr-number 123 \
-  --pr-url "https://github.com/org/repo/pull/123" \
-  --worktree $PATH
+  --result "PR created" --pr-number 123 --pr-url "URL" --worktree $PATH
 ```
-
-On failure:
-```bash
-~/.claude/skills/dev-kickoff/scripts/update-phase.sh <phase> failed --error "Error message" --worktree $PATH
-```
-
-### Resume After Compact
-
-1. Read `$WORKTREE/.claude/kickoff.json`
-2. Check `current_phase` and `next_actions`
-3. Resume from the pending phase
-
-## Workflow
-
-```
-git-prepare.sh → init-kickoff.sh → dev-issue-analyze → dev-implement → dev-validate → git-commit → git-pr → pr-iterate
-```
-
-After PR creation, kickoff.json is updated with PR info and `next_action: "pr-iterate"`. The pr-iterate skill automatically detects the worktree from kickoff.json.
 
 ## Phase Execution
 
 | Phase | Command | Subagent |
 |-------|---------|----------|
-| 1. Worktree | `~/.claude/skills/git-prepare/scripts/git-prepare.sh $ISSUE --base $BASE --env-mode $ENV_MODE` | - |
-| 1b. Init State | `~/.claude/skills/dev-kickoff/scripts/init-kickoff.sh ...` | - |
-| 2. Analyze | Skill: `dev-issue-analyze $ISSUE --depth $DEPTH` | Task(Explore) |
-| 3. Implement | Skill: `dev-implement --strategy $STRATEGY --worktree $PATH` | - |
-| 4. Validate | Skill: `dev-validate --fix --worktree $PATH` | Task(quality-engineer) |
-| 5. Commit | Skill: `git-commit --all --worktree $PATH` | - |
-| 6. Create PR | Skill: `git-pr $ISSUE --base $BASE --lang $LANG --worktree $PATH` | - |
+| 1 | `~/.claude/skills/git-prepare/scripts/git-prepare.sh $ISSUE --base $BASE --env-mode $ENV_MODE` | - |
+| 1b | `~/.claude/skills/dev-kickoff/scripts/init-kickoff.sh ...` | - |
+| 2 | `Skill: dev-issue-analyze $ISSUE --depth $DEPTH` | Task(Explore) |
+| 3 | `Skill: dev-implement --strategy $STRATEGY --worktree $PATH` | - |
+| 4 | `Skill: dev-validate --fix --worktree $PATH` | Task(quality-engineer) |
+| 5 | `Skill: git-commit --all --worktree $PATH` | - |
+| 6 | `Skill: git-pr $ISSUE --base $BASE --lang $LANG --worktree $PATH` | - |
 
-⚠️ **Phase 1 は必ずスクリプトを実行。`git worktree add` 直接実行禁止。**
-
-## Subagent Delegation
-
-| Phase | Subagent | Reason |
-|-------|----------|--------|
-| 2. Analyze | Task(Explore) | Large file reads, codebase exploration |
-| 4. Validate | Task(quality-engineer) | Test execution, log analysis |
-
-After subagent completes, update state with results:
-```bash
-# Example: record analyze results
-~/.claude/skills/dev-kickoff/scripts/update-phase.sh 2_analyze done \
-  --result "Identified 5 files to modify" \
-  --next "Create implementation tasks,Start with schema file" \
-  --worktree $PATH
-```
+⚠️ **Phase 1: 必ずスクリプト実行。`git worktree add` 直接実行禁止。**
 
 ## Phase 1 Verification
 
 ```bash
-ls $WORKTREE_PATH/.env || echo "ERROR: .env not linked - script was not used"
+ls $WORKTREE/.env || echo "ERROR: .env not linked"
 ```
-
-.env が存在しない場合はエラー報告し続行しない。
 
 ## Args
 
@@ -110,42 +91,20 @@ ls $WORKTREE_PATH/.env || echo "ERROR: .env not linked - script was not used"
 | `<issue-number>` | required | GitHub issue number |
 | `--strategy` | `tdd` | Implementation strategy |
 | `--depth` | `standard` | Analysis depth |
-| `--base` | `dev` | PR base branch |
+| `--base` | `main` | PR base branch |
 | `--lang` | `ja` | PR language |
 | `--env-mode` | `hardlink` | Env file handling |
-| `--skip-pr` | false | Skip PR creation |
 
 ## Error Handling
 
 | Phase | On Failure |
 |-------|------------|
-| Worktree/Analyze | Abort, update state with error |
-| Implement | Pause for intervention, save progress |
-| Validate | Retry with --fix, then pause |
-| Commit/PR | Report manual command, save state |
+| 1-2 | Abort, update state |
+| 3 | Pause for intervention |
+| 4 | Retry with --fix |
+| 5-6 | Report command, save state |
 
-## State File Location
+## References
 
-```
-$WORKTREE/
-├── .claude/
-│   ├── kickoff.json    # Machine-readable state
-│   └── iterate.json    # pr-iterate state (created after PR)
-└── docs/
-    └── STATE.md        # Human-readable summary (optional)
-```
-
-## kickoff.json Schema (with PR info)
-
-```json
-{
-  "issue": 123,
-  "worktree": "/path/to/worktree",
-  "pr": {
-    "number": 456,
-    "url": "https://github.com/org/repo/pull/456",
-    "created_at": "2026-01-28T10:00:00Z"
-  },
-  "next_action": "pr-iterate"
-}
-```
+- [Phase Details](references/phase-detail.md) - Detailed phase documentation
+- [State Schema](references/phase-detail.md#state-schema) - kickoff.json format

--- a/claude-code/skills/dev-kickoff/references/phase-detail.md
+++ b/claude-code/skills/dev-kickoff/references/phase-detail.md
@@ -1,0 +1,326 @@
+# Dev Kickoff - Phase Details
+
+Detailed documentation for each phase in the dev-kickoff workflow.
+
+## Phase Overview
+
+```
+Phase 1: Worktree Creation (git-prepare.sh)
+    ↓
+Phase 1b: State Initialization (init-kickoff.sh)
+    ↓
+Phase 2: Issue Analysis (dev-issue-analyze)
+    ↓
+Phase 3: Implementation (dev-implement)
+    ↓
+Phase 4: Validation (dev-validate)
+    ↓
+Phase 5: Commit (git-commit)
+    ↓
+Phase 6: PR Creation (git-pr)
+    ↓
+Handoff: pr-iterate
+```
+
+## Phase 1: Worktree Creation
+
+**Command:**
+```bash
+~/.claude/skills/git-prepare/scripts/git-prepare.sh $ISSUE --base $BASE --env-mode $ENV_MODE
+```
+
+**Purpose:** Create isolated git worktree for feature development.
+
+**Output:**
+- Worktree at `../{repo}-worktrees/feature-issue-{N}-m/`
+- Branch: `feature/issue-{N}-m`
+- Environment files linked/copied per `--env-mode`
+
+**Verification:**
+```bash
+ls $WORKTREE/.env || echo "ERROR: .env not found"
+```
+
+**Completion Criteria:**
+- Worktree directory exists
+- Branch created and checked out
+- .env file present (if env-mode != none)
+
+## Phase 1b: State Initialization
+
+**Command:**
+```bash
+~/.claude/skills/dev-kickoff/scripts/init-kickoff.sh $ISSUE $BRANCH $WORKTREE \
+  --base $BASE --strategy $STRATEGY --depth $DEPTH --lang $LANG --env-mode $ENV_MODE
+```
+
+**Purpose:** Create kickoff.json for state tracking.
+
+**Output:**
+- `$WORKTREE/.claude/kickoff.json` created
+- Phase 1 marked as "done"
+- Current phase set to "2_analyze"
+
+## Phase 2: Issue Analysis
+
+**Command:**
+```
+Skill: dev-issue-analyze $ISSUE --depth $DEPTH
+```
+
+**Subagent:** Task(Explore) - for large file reads and codebase exploration
+
+**Purpose:** Understand issue requirements and affected code.
+
+**Completion Criteria:**
+- Requirements documented
+- Affected files identified
+- Implementation approach determined
+
+**State Update:**
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 2_analyze done \
+  --result "Identified N files to modify" \
+  --worktree $PATH
+```
+
+## Phase 3: Implementation
+
+**Command:**
+```
+Skill: dev-implement --strategy $STRATEGY --worktree $PATH
+```
+
+**Purpose:** Write the actual code changes.
+
+**Strategies:**
+- `tdd`: Test-driven development (write tests first)
+- `bdd`: Behavior-driven development
+- `ddd`: Domain-driven design
+
+**Completion Criteria:**
+- All code changes written
+- Tests added (if TDD)
+- No syntax errors
+
+**State Update:**
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 3_implement done \
+  --result "Implemented feature X" \
+  --worktree $PATH
+```
+
+## Phase 4: Validation
+
+**Command:**
+```
+Skill: dev-validate --fix --worktree $PATH
+```
+
+**Subagent:** Task(quality-engineer) - for test execution and log analysis
+
+**Purpose:** Verify implementation works correctly.
+
+**Checks:**
+- Unit tests pass
+- Lint checks pass
+- Type checks pass (if applicable)
+- Integration tests pass
+
+**On Failure:**
+1. `--fix` attempts automatic fixes
+2. If still failing, pause for intervention
+3. Report specific failures
+
+**Completion Criteria:**
+- All tests pass
+- No lint errors
+- No type errors
+
+**State Update:**
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 4_validate done \
+  --result "All tests pass" \
+  --worktree $PATH
+```
+
+## Phase 5: Commit
+
+**Command:**
+```
+Skill: git-commit --all --worktree $PATH
+```
+
+**Purpose:** Create git commit with changes.
+
+**Commit Message:**
+- Generated based on changes
+- Follows conventional commits format
+- References issue number
+
+**Completion Criteria:**
+- All changes staged
+- Commit created
+- No uncommitted changes
+
+**State Update:**
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 5_commit done \
+  --result "Committed: <commit message>" \
+  --worktree $PATH
+```
+
+## Phase 6: PR Creation
+
+**Command:**
+```
+Skill: git-pr $ISSUE --base $BASE --lang $LANG --worktree $PATH
+```
+
+**Purpose:** Create GitHub Pull Request.
+
+**Output:**
+- PR created on GitHub
+- PR number and URL available
+
+**State Update (with PR info):**
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh 6_pr done \
+  --result "PR created" \
+  --pr-number 123 \
+  --pr-url "https://github.com/org/repo/pull/123" \
+  --worktree $PATH
+```
+
+This sets `next_action: "pr-iterate"` in kickoff.json.
+
+## Handoff to pr-iterate
+
+After Phase 6 completes:
+
+1. kickoff.json contains:
+   - `pr.number`: PR number
+   - `pr.url`: PR URL
+   - `next_action`: "pr-iterate"
+   - `current_phase`: "completed"
+
+2. Next action:
+   ```
+   Skill: pr-iterate $PR_URL
+   ```
+
+## State Schema
+
+### kickoff.json
+
+```json
+{
+  "version": "1.0",
+  "issue": 123,
+  "branch": "feature/issue-123-m",
+  "worktree": "/path/to/worktree",
+  "base_branch": "main",
+  "started_at": "2026-01-28T10:00:00Z",
+  "updated_at": "2026-01-28T12:00:00Z",
+  "current_phase": "3_implement",
+  "phases": {
+    "1_prepare": {
+      "status": "done",
+      "started_at": "2026-01-28T10:00:00Z",
+      "completed_at": "2026-01-28T10:01:00Z",
+      "result": "Worktree created"
+    },
+    "2_analyze": {
+      "status": "done",
+      "started_at": "2026-01-28T10:01:00Z",
+      "completed_at": "2026-01-28T10:15:00Z",
+      "result": "Identified 5 files"
+    },
+    "3_implement": {
+      "status": "in_progress",
+      "started_at": "2026-01-28T10:15:00Z"
+    },
+    "4_validate": { "status": "pending" },
+    "5_commit": { "status": "pending" },
+    "6_pr": { "status": "pending" }
+  },
+  "next_actions": ["Continue implementation"],
+  "decisions": [],
+  "config": {
+    "strategy": "tdd",
+    "depth": "standard",
+    "lang": "ja",
+    "env_mode": "hardlink"
+  }
+}
+```
+
+### After PR Creation
+
+```json
+{
+  "current_phase": "completed",
+  "pr": {
+    "number": 456,
+    "url": "https://github.com/org/repo/pull/456",
+    "created_at": "2026-01-28T12:00:00Z"
+  },
+  "next_action": "pr-iterate"
+}
+```
+
+## Subagent Delegation
+
+| Phase | Subagent | Why |
+|-------|----------|-----|
+| 2 | Task(Explore) | Large codebase reads, file discovery |
+| 4 | Task(quality-engineer) | Test execution, failure analysis |
+
+Other phases run directly without subagent delegation.
+
+## Error Handling
+
+### Phase 1-2 Failures
+
+```bash
+~/.claude/skills/dev-kickoff/scripts/update-phase.sh $PHASE failed \
+  --error "Error message" \
+  --worktree $PATH
+```
+
+Action: Abort workflow, report error.
+
+### Phase 3 Failures
+
+Action: Pause for intervention, save progress.
+
+### Phase 4 Failures
+
+1. Retry with `--fix`
+2. If still failing, pause
+3. Report specific test failures
+
+### Phase 5-6 Failures
+
+Action: Report manual command to run, save state.
+
+Manual recovery:
+```bash
+# Phase 5
+git add -A && git commit -m "feat: ..."
+
+# Phase 6
+gh pr create --title "..." --body "..."
+```
+
+## Recovery Commands
+
+Check current state:
+```bash
+~/.claude/skills/dev-kickoff/scripts/next-action.sh --worktree $PATH
+```
+
+Resume from current phase:
+```bash
+# Read next_action from output and execute
+```

--- a/claude-code/skills/dev-kickoff/scripts/init-kickoff.sh
+++ b/claude-code/skills/dev-kickoff/scripts/init-kickoff.sh
@@ -18,7 +18,6 @@ STRATEGY="tdd"
 DEPTH="standard"
 LANG="ja"
 ENV_MODE="hardlink"
-SKIP_PR="false"
 
 # Valid enum values
 VALID_STRATEGIES="tdd bdd ddd none"
@@ -34,7 +33,6 @@ while [[ $# -gt 0 ]]; do
         --depth) DEPTH="$2"; shift 2 ;;
         --lang) LANG="$2"; shift 2 ;;
         --env-mode) ENV_MODE="$2"; shift 2 ;;
-        --skip-pr) SKIP_PR="true"; shift ;;
         -*)
             die_json "Unknown option: $1" 1
             ;;
@@ -98,7 +96,6 @@ jq -n \
     --arg depth "$DEPTH" \
     --arg lang "$LANG" \
     --arg env_mode "$ENV_MODE" \
-    --argjson skip_pr "$SKIP_PR" \
     '{
         version: "1.0",
         issue: $issue,
@@ -122,8 +119,7 @@ jq -n \
             strategy: $strategy,
             depth: $depth,
             lang: $lang,
-            env_mode: $env_mode,
-            skip_pr: $skip_pr
+            env_mode: $env_mode
         }
     }' > "$STATE_FILE"
 

--- a/claude-code/skills/dev-kickoff/scripts/next-action.sh
+++ b/claude-code/skills/dev-kickoff/scripts/next-action.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# next-action.sh - Determine next action based on current phase
+# Usage: next-action.sh [--worktree PATH]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        -*)
+            die_json "Unknown option: $1" 1
+            ;;
+        *)
+            if [[ -z "$WORKTREE" ]]; then
+                WORKTREE="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Find state file
+if [[ -n "$WORKTREE" ]]; then
+    [[ -d "$WORKTREE" ]] || die_json "Worktree path does not exist: $WORKTREE" 1
+    WORKTREE=$(cd "$WORKTREE" && pwd) || die_json "Cannot resolve worktree path" 1
+    STATE_FILE="$WORKTREE/.claude/kickoff.json"
+else
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -n "$GIT_ROOT" && -f "$GIT_ROOT/.claude/kickoff.json" ]]; then
+        STATE_FILE="$GIT_ROOT/.claude/kickoff.json"
+        WORKTREE="$GIT_ROOT"
+    else
+        die_json "State file not found. Use --worktree or run from worktree directory." 1
+    fi
+fi
+
+[[ -f "$STATE_FILE" ]] || die_json "State file not found: $STATE_FILE" 1
+
+# Read state
+CURRENT_PHASE=$(jq -r '.current_phase // "unknown"' "$STATE_FILE")
+ISSUE=$(jq -r '.issue // "unknown"' "$STATE_FILE")
+BASE_BRANCH=$(jq -r '.base_branch // "main"' "$STATE_FILE")
+STRATEGY=$(jq -r '.config.strategy // "tdd"' "$STATE_FILE")
+DEPTH=$(jq -r '.config.depth // "standard"' "$STATE_FILE")
+LANG=$(jq -r '.config.lang // "ja"' "$STATE_FILE")
+PR_NUMBER=$(jq -r '.pr.number // ""' "$STATE_FILE")
+PR_URL=$(jq -r '.pr.url // ""' "$STATE_FILE")
+
+# Get phase status
+get_phase_status() {
+    local phase="$1"
+    jq -r ".phases[\"$phase\"].status // \"pending\"" "$STATE_FILE"
+}
+
+# Determine next action
+determine_next_action() {
+    case "$CURRENT_PHASE" in
+        1_prepare)
+            local status=$(get_phase_status "1_prepare")
+            if [[ "$status" == "done" ]]; then
+                echo "2_analyze"
+                echo "Skill: dev-issue-analyze $ISSUE --depth $DEPTH"
+            else
+                echo "1_prepare"
+                echo "~/.claude/skills/git-prepare/scripts/git-prepare.sh $ISSUE --base $BASE_BRANCH"
+            fi
+            ;;
+        2_analyze)
+            local status=$(get_phase_status "2_analyze")
+            if [[ "$status" == "done" ]]; then
+                echo "3_implement"
+                echo "Skill: dev-implement --strategy $STRATEGY --worktree $WORKTREE"
+            else
+                echo "2_analyze"
+                echo "Skill: dev-issue-analyze $ISSUE --depth $DEPTH"
+            fi
+            ;;
+        3_implement)
+            local status=$(get_phase_status "3_implement")
+            if [[ "$status" == "done" ]]; then
+                echo "4_validate"
+                echo "Skill: dev-validate --fix --worktree $WORKTREE"
+            else
+                echo "3_implement"
+                echo "Skill: dev-implement --strategy $STRATEGY --worktree $WORKTREE"
+            fi
+            ;;
+        4_validate)
+            local status=$(get_phase_status "4_validate")
+            if [[ "$status" == "done" ]]; then
+                echo "5_commit"
+                echo "Skill: git-commit --all --worktree $WORKTREE"
+            else
+                echo "4_validate"
+                echo "Skill: dev-validate --fix --worktree $WORKTREE"
+            fi
+            ;;
+        5_commit)
+            local status=$(get_phase_status "5_commit")
+            if [[ "$status" == "done" ]]; then
+                echo "6_pr"
+                echo "Skill: git-pr $ISSUE --base $BASE_BRANCH --lang $LANG --worktree $WORKTREE"
+            else
+                echo "5_commit"
+                echo "Skill: git-commit --all --worktree $WORKTREE"
+            fi
+            ;;
+        6_pr)
+            local status=$(get_phase_status "6_pr")
+            if [[ "$status" == "done" ]]; then
+                echo "pr-iterate"
+                if [[ -n "$PR_URL" ]]; then
+                    echo "Skill: pr-iterate $PR_URL"
+                else
+                    echo "Skill: pr-iterate $PR_NUMBER"
+                fi
+            else
+                echo "6_pr"
+                echo "Skill: git-pr $ISSUE --base $BASE_BRANCH --lang $LANG --worktree $WORKTREE"
+            fi
+            ;;
+        completed)
+            if [[ -n "$PR_URL" ]]; then
+                echo "pr-iterate"
+                echo "Skill: pr-iterate $PR_URL"
+            else
+                echo "completed"
+                echo "Workflow complete"
+            fi
+            ;;
+        *)
+            echo "unknown"
+            echo "Unknown state - check kickoff.json"
+            ;;
+    esac
+}
+
+# Get next action
+read -r NEXT_PHASE NEXT_CMD <<< "$(determine_next_action | paste - -)"
+
+# Output JSON
+jq -n \
+    --arg current_phase "$CURRENT_PHASE" \
+    --arg next_phase "$NEXT_PHASE" \
+    --arg next_cmd "$NEXT_CMD" \
+    --argjson issue "$ISSUE" \
+    --arg worktree "$WORKTREE" \
+    --arg pr_number "${PR_NUMBER:-null}" \
+    --arg pr_url "${PR_URL:-null}" \
+    '{
+        current_phase: $current_phase,
+        next_phase: $next_phase,
+        next_action: $next_cmd,
+        issue: $issue,
+        worktree: $worktree,
+        pr: (if $pr_number != "null" and $pr_number != "" then { number: ($pr_number | tonumber), url: $pr_url } else null end)
+    }'


### PR DESCRIPTION
## Summary

dev-flowがPhase 5 (commit)完了後に停止する問題を修正し、2026 Best Practiceに準拠するよう改善。

### 変更内容

**dev-flow:**
- ⚠️ CRITICAL セクション追加（「終了するな」の明示）
- Checklist Patternによる進捗追跡
- 完了条件を表形式で明記
- `scripts/flow-status.sh` 新規作成（状態確認・次アクション出力）
- `references/workflow-detail.md` 新規作成（詳細ドキュメント）

**dev-kickoff:**
- SKILL.md簡潔化（152行→110行）
- ⚠️ CRITICAL セクション追加
- Phase Checklist追加
- `--skip-pr` フラグ削除（不要と判断）
- `scripts/next-action.sh` 新規作成（次アクション判定）
- `references/phase-detail.md` 新規作成（詳細フェーズ説明）

### 2026 Best Practice準拠状況

| Practice | Before | After |
|----------|--------|-------|
| Checklist Pattern | ❌ | ✅ |
| Explicit "don't exit" | ❌ | ✅ |
| Completion conditions | ❌ | ✅ |
| Script-driven next action | △ | ✅ |
| SKILL.md最小化 | ❌ | ✅ |

## Test Plan

- [x] `flow-status.sh` スクリプト構文チェック通過
- [x] `next-action.sh` スクリプト構文チェック通過
- [x] 実際の状態ファイルでスクリプト動作確認
- [ ] 実際の `/dev-flow` 実行で最後まで完了することを確認

Closes #21