### PR TITLE
fix(skills): require_gh_auth 無効アカウント対応 (#23)

### DIFF
--- a/claude-code/skills/_lib/common.sh
+++ b/claude-code/skills/_lib/common.sh
@@ -81,7 +81,10 @@ require_git_repo() {
 
 require_gh_auth() {
     require_cmd "gh" "GitHub CLI (gh) not installed. Install: brew install gh"
-    gh auth status &>/dev/null 2>&1 || die_json "GitHub CLI not authenticated. Run: gh auth login" 129
+    # Use 'gh auth token' instead of 'gh auth status' to check authentication
+    # 'gh auth status' returns exit code 1 if ANY account is invalid, even if active account works
+    # 'gh auth token' only checks if active account has a valid token
+    gh auth token &>/dev/null || die_json "GitHub CLI not authenticated. Run: gh auth login" 129
 }
 
 require_cmds() {


### PR DESCRIPTION
## 概要

`require_gh_auth` 関数が無効なアカウントがあるとエラーを返す問題を修正。

## 変更内容

- `gh auth status` → `gh auth token` に変更
- `gh auth status` は無効なアカウントが1つでもあると exit code 1
- `gh auth token` はアクティブアカウントのトークン存在のみを確認

## 影響範囲

以下のスクリプトで使用される `require_gh_auth` が正常に動作するようになる:
- `dev-issue-analyze/scripts/analyze-issue.sh`
- `pr-fix/scripts/pr-setup.sh`
- `pr-iterate/scripts/pr-iterate-setup.sh`
- `pr-iterate/scripts/post-summary.sh`
- `pr-iterate/scripts/init-iterate.sh`

## テスト

```bash
# Before: gh auth status fails with invalid accounts
gh auth status &>/dev/null && echo OK || echo FAIL  # FAIL

# After: gh auth token works
gh auth token &>/dev/null && echo OK || echo FAIL   # OK
```

Closes #23