### PR TITLE
🐛 fix(skills): dev-flowがPRを自動mergeしないよう修正 (#26)

### DIFF
--- a/claude-code/skills/dev-flow/SKILL.md
+++ b/claude-code/skills/dev-flow/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: dev-flow
 description: |
-  End-to-end development flow automation - from issue to merged PR.
+  End-to-end development flow automation - from issue to LGTM.
+  Note: Merge is performed manually by the user after review approval.
   Use when: (1) complete development cycle needed, (2) issue to PR automation,
   (3) keywords: full flow, development cycle, issue to PR
   Accepts args: <issue-number> [--strategy tdd|bdd|ddd] [--depth minimal|standard|comprehensive] [--base <branch>] [--max-iterations N]
@@ -12,7 +13,7 @@ allowed-tools:
 
 # Dev Flow
 
-End-to-end development automation from issue to merged PR.
+End-to-end development automation from issue to LGTM (merge manually).
 
 ## ⚠️ CRITICAL: Complete All Phases
 
@@ -22,7 +23,7 @@ End-to-end development automation from issue to merged PR.
 |------|--------|---------------|
 | 1 | `Skill: dev-kickoff` | PR URL available |
 | 2 | `gh pr view --json url` | URL captured |
-| 3 | `Skill: pr-iterate` | PR merged or max iterations |
+| 3 | `Skill: pr-iterate` | LGTM achieved or max iterations |
 
 ## Usage
 
@@ -45,9 +46,13 @@ Execute in order. Mark each complete before proceeding:
 | Condition | Action |
 |-----------|--------|
 | pr-iterate completes | ✅ Workflow complete |
-| PR merged | ✅ Workflow complete |
+| LGTM achieved | ✅ Workflow complete (merge manually) |
 | Max iterations reached | ⚠️ Report status, user decides |
 | Any step fails | ❌ Report error, do not proceed |
+
+## ⚠️ Important: No Auto-Merge
+
+**This workflow does NOT merge the PR.** After achieving LGTM, the user should manually merge using `gh pr merge` or the GitHub UI.
 
 ## State Recovery
 

--- a/claude-code/skills/dev-flow/references/workflow-detail.md
+++ b/claude-code/skills/dev-flow/references/workflow-detail.md
@@ -135,4 +135,4 @@ cat $WORKTREE/.claude/kickoff.json | jq '.pr'
 ### With GitHub CLI
 - `gh pr view` for PR status
 - `gh pr checks` for CI status
-- `gh pr merge` when ready
+- `gh pr merge` - User performs manually after LGTM (not automated by this workflow)

--- a/claude-code/skills/pr-iterate/SKILL.md
+++ b/claude-code/skills/pr-iterate/SKILL.md
@@ -12,6 +12,10 @@ allowed-tools:
 
 # PR Iterate
 
+## ⚠️ Important: No Auto-Merge
+
+**This skill does NOT merge the PR.** After achieving LGTM, the user should manually merge using `gh pr merge` or the GitHub UI.
+
 ## Usage
 
 ```


### PR DESCRIPTION
## 概要

`/dev-flow` スキル実行時、PRがLGTMを得た後に自動でマージまで実行されてしまう問題を修正。

## 変更内容

ドキュメントの記述がClaudeに「mergeまで実行する」と誤解させていたため、以下を修正:

- `dev-flow/SKILL.md`: 
  - description を「from issue to merged PR」→「from issue to LGTM」に変更
  - 完了条件を「PR merged」→「LGTM achieved」に変更
  - 「No Auto-Merge」セクションを追加
- `pr-iterate/SKILL.md`:
  - 「No Auto-Merge」セクションを追加
- `workflow-detail.md`:
  - `gh pr merge` は手動で行うことを明記

## 修正理由

1. **安全性**: 自動mergeは危険。レビュー承認後も人間がマージタイミングを制御すべき
2. **CI/CD連携**: 多くのプロジェクトでmergeにはCIパス、承認者条件等がある
3. **ユーザー意図**: LGTM取得後の最終確認は人間が行うべき

## テスト計画

- [ ] `/dev-flow` 実行後、LGTMを得たらワークフロー終了（mergeしない）
- [ ] ドキュメントから「merged PR」の表現を削除/修正されている
- [ ] 「マージは手動」であることが明記されている

Closes #26