### PR TITLE
feat(hooks): PreToolUse(Bash) で prod credential 検知 hook を追加 (#46)

### DIFF
--- a/claude-code/hooks/pretool-bash-credential-guard.sh
+++ b/claude-code/hooks/pretool-bash-credential-guard.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: prod credential 露出の検知
+#
+# 目的:
+#   long-running session で Bash 経由に prod 環境の credential が露出することを
+#   deterministic に防ぐ。検知時は permissionDecision="ask" を返して、
+#   ユーザーに明示的な確認を求める（完全 deny ではなく escape 可能）。
+#
+# 検知対象:
+#   1. 環境変数参照: $PROD_*, ${PRODUCTION_*}, $LIVE_*
+#      - 必ず `_` サフィックスを要求することで $PRODUCER のような false positive を回避
+#   2. .env.production / .env.prod ファイルの読み込み
+#      - cat/less/more/head/tail/source/./grep/awk/sed/bat 等任意のコマンド
+#   3. aws --profile に prod を含むプロファイル名
+#      - aws ... --profile prod / --profile=prod-admin / --profile my-prod-read
+#
+# 出力:
+#   - 検知時: stdout に
+#       {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#         "permissionDecision":"ask",
+#         "permissionDecisionReason":"<理由>"}}
+#   - 非検知時: stdout 空で exit 0（チェーン通過 → Claude 通常の permission flow）
+#
+# 誤検知（false-positive）テストケース:
+#   以下は検知「しない」ことをテストで担保している。
+#     - echo $HOME / echo $PATH                （一般的な変数）
+#     - echo "product listing" / ls products/  （product は検知しない）
+#     - echo $PRODUCER                         （PROD + UCER、_ 区切りなし）
+#     - git log --grep=production              （.env.production ファイルではない）
+#     - cat .env.test / .env.development / .env.staging
+#     - echo $STAGING_API_KEY / echo $DEV_TOKEN
+#     - aws --profile staging / --profile default
+#   詳細は pretool-bash-credential-guard.test.sh を参照。
+#
+# 参考:
+#   - Simon Willison: Designing agentic loops (credential scoping to test/staging)
+#   - Simon Willison: Parallel coding agents (blast radius containment)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Bash ツール以外は対象外
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+if [[ $TOOL != "Bash" ]]; then
+  exit 0
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+if [[ -z $CMD ]]; then
+  exit 0
+fi
+
+emit_ask() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# --- 1. PROD/PRODUCTION/LIVE 環境変数参照 ---
+# $PROD_XXX / ${PROD_XXX} / $PRODUCTION_XXX / $LIVE_XXX 形式を検知
+# PROD/PRODUCTION/LIVE の直後に `_` が必須（$PRODUCER 等を除外）
+if echo "$CMD" | grep -qE '\$\{?(PROD|PRODUCTION|LIVE)_[A-Z0-9_]+'; then
+  MATCH=$(echo "$CMD" | grep -oE '\$\{?(PROD|PRODUCTION|LIVE)_[A-Z0-9_]+' | head -1)
+  emit_ask "prod credential env var を検知: ${MATCH}"
+fi
+
+# --- 2. .env.production / .env.prod ファイルの参照 ---
+# 単語境界で `.env.production` または `.env.prod` が登場するケースを検知
+# ファイル名末尾 (空白/行末/引用符/セミコロン/パイプ/リダイレクト) で境界を判定
+if echo "$CMD" | grep -qE '(^|[[:space:]/"'"'"'=])\.env\.(production|prod)([[:space:]"'"'"';|&<>]|$)'; then
+  MATCH=$(echo "$CMD" | grep -oE '\.env\.(production|prod)' | head -1)
+  emit_ask "prod env ファイル参照を検知: ${MATCH}"
+fi
+
+# --- 3. aws --profile に prod を含むプロファイル名 ---
+# `aws` コマンドかつ `--profile <name>` or `--profile=<name>` に prod を含む
+if echo "$CMD" | grep -qE '(^|[[:space:]])aws([[:space:]]|$)'; then
+  # --profile <value> または --profile=<value> を抽出
+  PROFILE=$(echo "$CMD" | grep -oE -- '--profile[= ][^[:space:]]+' | head -1 | sed -E 's/^--profile[= ]//')
+  if [[ -n $PROFILE ]] && echo "$PROFILE" | grep -qiE 'prod'; then
+    emit_ask "aws prod profile を検知: --profile ${PROFILE}"
+  fi
+fi
+
+# 検知なし: pass-through
+exit 0

--- a/claude-code/hooks/pretool-bash-credential-guard.test.sh
+++ b/claude-code/hooks/pretool-bash-credential-guard.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Test suite for pretool-bash-credential-guard.sh
+#
+# Usage: bash pretool-bash-credential-guard.test.sh
+#
+# Exit 0 on all pass, non-zero otherwise.
+#
+# shellcheck disable=SC2016
+# 単一引用符内の `$VAR` は意図的なリテラル（hook に生文字列として渡す）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/pretool-bash-credential-guard.sh"
+
+if [[ ! -x ${HOOK} ]]; then
+  echo "FAIL: hook not executable: ${HOOK}" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# run_case <name> <command> <expected: ask|pass>
+run_case() {
+  local name="$1"
+  local cmd="$2"
+  local expected="$3"
+
+  local input
+  input=$(jq -n --arg cmd "$cmd" '{tool_name:"Bash", tool_input:{command:$cmd}}')
+
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+
+  local decision="pass"
+  if [[ -n $output ]]; then
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null || echo "pass")
+  fi
+
+  if [[ $decision == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    printf "  \033[32mPASS\033[0m %s\n" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected=$expected got=$decision cmd=$cmd")
+    printf "  \033[31mFAIL\033[0m %s (expected=%s, got=%s)\n" "$name" "$expected" "$decision"
+  fi
+}
+
+echo "=== pretool-bash-credential-guard tests ==="
+
+# --- Positive cases: should trigger "ask" ---
+echo "[Positive cases — should detect]"
+run_case "PROD env var reference" 'echo $PROD_API_KEY' "ask"
+run_case "PROD env var with braces" 'echo ${PROD_DB_PASSWORD}' "ask"
+run_case "PRODUCTION env var reference" 'echo $PRODUCTION_SECRET' "ask"
+run_case "LIVE env var reference" 'curl -H "X: $LIVE_TOKEN" https://api.example.com' "ask"
+run_case "cat .env.production" 'cat .env.production' "ask"
+run_case "cat .env.prod" 'cat .env.prod' "ask"
+run_case "source .env.production" 'source .env.production' "ask"
+run_case "grep in .env.production" 'grep KEY .env.production' "ask"
+run_case "aws --profile prod" 'aws s3 ls --profile prod' "ask"
+run_case "aws --profile my-prod-admin" 'aws --profile my-prod-admin sts get-caller-identity' "ask"
+
+# --- Negative cases: should NOT trigger ---
+echo "[Negative cases — should pass through]"
+run_case 'echo $HOME' 'echo $HOME' "pass"
+run_case 'echo $PATH' 'echo $PATH' "pass"
+run_case "ls -la" 'ls -la' "pass"
+run_case "git status" 'git status' "pass"
+run_case "cat .env.test" 'cat .env.test' "pass"
+run_case "cat .env.development" 'cat .env.development' "pass"
+run_case "cat .env.staging" 'cat .env.staging' "pass"
+run_case 'echo $STAGING_API_KEY' 'echo $STAGING_API_KEY' "pass"
+run_case 'echo $DEV_TOKEN' 'echo $DEV_TOKEN' "pass"
+run_case "aws --profile staging" 'aws s3 ls --profile staging' "pass"
+run_case "aws --profile default" 'aws sts get-caller-identity --profile default' "pass"
+
+# --- False-positive guard cases (documented) ---
+echo "[False-positive guard — should pass through]"
+# The word "prod" appearing in unrelated context should not trigger.
+run_case "echo product listing" 'echo "product listing"' "pass"
+run_case "ls products/" 'ls products/' "pass"
+run_case "git log --grep production" 'git log --grep=production' "pass"
+# $PRODUCER is not PROD_ / PRODUCTION_ / LIVE_ — should not match (word boundary)
+run_case 'echo $PRODUCER' 'echo $PRODUCER' "pass"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if ((FAIL > 0)); then
+  printf '\n'
+  printf 'Failures:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -305,6 +305,17 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/pretool-bash-credential-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "prod credential 検知中..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash \"$HOME/.claude/hooks/generate-worktreeinclude.sh\"",
             "if": "Bash(git worktree add*)",
             "timeout": 10,


### PR DESCRIPTION
## 概要

long-running session で Bash 経由に prod 環境の credential が露出することを deterministic に防ぐため、PreToolUse(Bash) hook `pretool-bash-credential-guard.sh` を新設します。

Closes #46

## 背景

- [Simon Willison: Designing agentic loops](https://simonwillison.net/2025/Sep/30/designing-agentic-loops/) — credential は test/staging に $5 budget 付きで scope するべき
- [Simon Willison: Parallel coding agents](https://simonwillison.net/2025/Oct/5/parallel-coding-agents/) — blast radius 封じ込めの重要性
- 既存 hooks は `rm -rf` 等の破壊的コマンド deny は整備済みだが、credential レベルの検査が薄い

## 実装内容

### 新規: `claude-code/hooks/pretool-bash-credential-guard.sh`

PreToolUse(Bash) で受け取った JSON から `.tool_input.command` を抽出し、以下のパターンを検知した場合に `permissionDecision="ask"` を返す（完全 deny ではなく ask で誤検知時の escape を確保）。

**検知対象:**

| # | 対象 | 正規表現要点 |
|---|------|-------------|
| 1 | 環境変数参照 `$PROD_*` / `${PRODUCTION_*}` / `$LIVE_*` | `_` サフィックスを必須化して `$PRODUCER` を除外 |
| 2 | `.env.production` / `.env.prod` ファイル参照 | 単語境界判定で `cat` / `source` / `grep` 等の任意コマンドに対応 |
| 3 | `aws --profile <name>` の `<name>` に `prod` を含む | `--profile=` 記法にも対応 |

known-prod host への curl/http は allow-list 必須で誤検知が出やすいため、今回は見送り（将来追加可能）。

### 変更: `claude-code/settings.json`

既存の PreToolUse(Bash) matcher 配下に新 hook を chain。

```json
{
  "matcher": "Bash",
  "hooks": [
    {
      "type": "command",
      "command": "bash \"$HOME/.claude/hooks/pretool-bash-credential-guard.sh\"",
      "timeout": 5,
      "statusMessage": "prod credential 検知中..."
    }
  ]
}
```

hook は `~/.claude/hooks/` に `scripts/setup-skills.sh` の symlink 経由で反映されます。

### 新規: `claude-code/hooks/pretool-bash-credential-guard.test.sh`

TDD で作成した 25 件のテストケース（positive / negative / false-positive guard）を同梱。hook に JSON を stdin から流し込み、`permissionDecision` を assert します。

実行:

```bash
bash claude-code/hooks/pretool-bash-credential-guard.test.sh
```

結果: `25 passed, 0 failed`

## 受け入れ条件

- [x] hook script が実在（`claude-code/hooks/pretool-bash-credential-guard.sh`）
- [x] `echo $PROD_API_KEY` で `ask` が発火する（test case で担保）
- [x] `cat .env.production` で `ask` が発火する（test case で担保）
- [x] 通常の `echo $HOME` では発火しない（test case で担保）
- [x] 誤検知テストケースを script header にドキュメント化（`echo "product listing"` / `$PRODUCER` / `--grep=production` / `.env.test` 等）

## 誤検知（false-positive）ガード

script header と test suite に以下のケースを明示し、検知されないことを保証しています。

- `echo $HOME` / `echo $PATH`（一般変数）
- `echo "product listing"` / `ls products/`（`product` 単語は無視）
- `echo $PRODUCER`（`PROD` + `UCER`、`_` 区切りなしなので除外）
- `git log --grep=production`（`.env.production` ファイルではない）
- `cat .env.test` / `.env.development` / `.env.staging`
- `echo $STAGING_API_KEY` / `echo $DEV_TOKEN`
- `aws --profile staging` / `--profile default`

## テスト計画

- [x] `bash claude-code/hooks/pretool-bash-credential-guard.test.sh` で 25/25 pass を確認
- [x] `shellcheck` で新規 2 ファイルを確認（warning なし）
- [x] `jq empty claude-code/settings.json` で JSON 構文検証
- [ ] 手動 E2E: 別 session で `echo $PROD_API_KEY` を実行して `ask` ダイアログが出ることを確認（マージ後）