### PR TITLE
fix(claude-code): gh pr merge hook が全 Bash で発火する不具合を修正

### DIFF
--- a/claude-code/hooks/allow-pr-merge.sh
+++ b/claude-code/hooks/allow-pr-merge.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PreToolUse hook: gh pr merge の base branch チェック
+# - base が nightly/* → allow
+# - それ以外 → ask
+# - PR 番号不明 / 判定不能 → ask
+
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$CMD" in
+  "gh pr merge "*) ;;
+  *) exit 0 ;;
+esac
+
+PR_NUM=$(echo "$CMD" | grep -oE '[0-9]+' | head -1)
+if [ -z "$PR_NUM" ]; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"PR番号を検出できません"}}'
+  exit 0
+fi
+
+BASE=$(gh pr view "$PR_NUM" --json baseRefName -q .baseRefName 2>/dev/null || true)
+
+if echo "$BASE" | grep -qE '^nightly/'; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"nightly branch merge allowed"}}'
+else
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"base=%s — nightly/* 以外はユーザー確認が必要"}}\n' "$BASE"
+fi

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -317,8 +317,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; pr_num=$(echo \"$cmd\" | grep -oE '[0-9]+' | head -1); if [ -z \"$pr_num\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"PR番号を検出できません\"}}'; exit 0; fi; base=$(gh pr view \"$pr_num\" --json baseRefName -q .baseRefName 2>/dev/null); if echo \"$base\" | grep -qE '^nightly/'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"permissionDecisionReason\":\"nightly branch merge allowed\"}}'; else echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"base='\"$base\"' — nightly/* 以外はユーザー確認が必要\"}}'; fi; }",
-            "if": "Bash(gh pr merge *)",
+            "command": "bash \"$HOME/.claude/hooks/allow-pr-merge.sh\"",
+            "if": "Bash(gh pr merge*)",
             "timeout": 15,
             "statusMessage": "PR merge ブランチチェック中..."
           }


### PR DESCRIPTION
## 概要

`PreToolUse` hook の `gh pr merge` base branch チェックが、本来対象外の全 Bash コマンドに対しても発火していた問題を修正。

## 原因

- 該当 hook は `if: Bash(gh pr merge *)` のみに依存しており、内部ガード句が無かった
- `if` パターンの末尾に余計なスペースがあり、他エントリ (`Bash(git push*)` 等) と不統一
- `if` が機能しない状況で全 Bash コマンドに対してスクリプトが走り、`grep -oE '[0-9]+'` がコマンド中の数字を拾って `gh pr view` を失敗させ、`base= — nightly/* 以外はユーザー確認が必要` ダイアログが頻発していた

## 変更点

- `claude-code/hooks/allow-pr-merge.sh` を新規作成し、巨大インラインコマンドを切り出し
  - 先頭で `case "$CMD" in "gh pr merge "*) ;; *) exit 0 ;; esac` の内部ガードを追加
  - `allow-feature-push.sh` と同じ二重防御パターンに統一
- `settings.json` の該当エントリ:
  - command を `bash "$HOME/.claude/hooks/allow-pr-merge.sh"` に差し替え
  - `if` を `Bash(gh pr merge *)` → `Bash(gh pr merge*)` に統一

## 動作確認

- `bash -n` 構文チェック OK
- `ls -la` 等の無関係な Bash コマンドを流し込むと静かに exit 0
- `gh pr merge 123` 相当の入力では従来どおりの判定ロジックが動く

## Test plan

- [ ] Claude Code 再起動後、普通の Bash 実行で `nightly/*` ダイアログが出ないことを確認
- [ ] `gh pr merge <num>` 実行時に base branch チェックが従来どおり動作することを確認