### PR TITLE
chore(claude-code): additionalDirectories をチルダ展開に変更

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -203,9 +203,9 @@
     "defaultMode": "auto",
     "disableBypassPermissionsMode": "disable",
     "additionalDirectories": [
-      "/Users/naramotoyuuji/ghq/github.com/playpark-llc",
-      "/Users/naramotoyuuji/ghq/github.com/it-all-playpark",
-      "/Users/naramotoyuuji/ghq/github.com/Cistree-dev"
+      "~/ghq/github.com/playpark-llc",
+      "~/ghq/github.com/it-all-playpark",
+      "~/ghq/github.com/Cistree-dev"
     ]
   },
   "enableAllProjectMcpServers": false,


### PR DESCRIPTION
ハードコードされたホームパスをマシン非依存な `~/ghq/...` 形式へ置き換え。
Claude Code の settings.json パーサーは `~` の展開をサポートしている （`$HOME` は未対応）ため、他ユーザー/マシンへの可搬性が向上する。