### PR TITLE
feat(claude-code): PostToolUse で Bash 出力の秘匿情報をマスク

### DIFF
--- a/claude-code/hooks/posttool-secret-mask.sh
+++ b/claude-code/hooks/posttool-secret-mask.sh
@@ -26,11 +26,18 @@
 #     - JWT tokens (eyJ.eyJ.signature)
 #   Generic fallback (誤検知ありうるが backstop として):
 #     - 環境変数形式 <NAME_WITH_KEY|TOKEN|SECRET|PASSWORD|...>=<value 16+chars>
+#       (行頭 whitespace / インデント付きも対象)
+# 対象外 (Phase 2 候補):
+#   - 小文字 env 名 (password=..., apiKey: ...)
+#   - URL 埋め込み credential (postgres://user:secret@host)
+#   - YAML/JSON inline (apiKey: "...", "token": "...")
+#   - Read/Edit/Write tool 出力 (現在 Bash のみ対応)
 #
 # 出力:
-#   - マスク発生時: stdout に
+#   - マスク発生時 (Bash tool): stdout に
 #       {"hookSpecificOutput":{"hookEventName":"PostToolUse",
-#         "updatedToolOutput":{"type":"text","text":"<masked>"}}}
+#         "updatedToolOutput": <元 tool_response に stdout/stderr を上書きした object>}}
+#   - 他 tool (Read/Edit/Write/MCP 等): stdout 空で exit 0 (pass-through)
 #   - マスクなし: stdout 空で exit 0 (Claude はオリジナル出力を見る)
 #
 # 注意:
@@ -43,8 +50,12 @@
 set -euo pipefail
 
 INPUT=$(cat)
+[[ -z $INPUT ]] && exit 0
 
 # Debug: CLAUDE_HOOK_DEBUG=1 で入力 JSON を /tmp に保存
+# 注意: 本ログは append-only で size 制限なし。CLAUDE_HOOK_DEBUG=1 を export した
+# まま長期間運用すると蓄積するため、debug 完了後は env を unset し、ログファイル
+# を手動削除すること。
 if [[ ${CLAUDE_HOOK_DEBUG:-0} == 1 ]]; then
   {
     printf '=== %s tool=%s ===\n' "$(date -Iseconds 2>/dev/null || date)" "$(echo "$INPUT" | jq -r '.tool_name // "?"')"
@@ -107,7 +118,8 @@ mask_text() {
     s/\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/[REDACTED:JWT]/g;
 
     # Generic env-style fallback (specific 済みは (?!\[REDACTED:) で除外)
-    s/^((?:[A-Z][A-Z0-9_]*_)?(?:TOKEN|KEY|SECRET|PASSWORD|PASSPHRASE|CREDENTIAL|BEARER)[A-Z0-9_]*)=(?!\[REDACTED:)([^\s\r\n]{16,})$/$1=[REDACTED:ENV_SECRET]/gm;
+    # 行頭 whitespace (インデント) も許容
+    s/(^|[\s])((?:[A-Z][A-Z0-9_]*_)?(?:TOKEN|KEY|SECRET|PASSWORD|PASSPHRASE|CREDENTIAL|BEARER)[A-Z0-9_]*)=(?!\[REDACTED:)([^\s\r\n]{16,})($|[\s])/$1$2=[REDACTED:ENV_SECRET]$4/gm;
   '
 }
 
@@ -129,20 +141,13 @@ if [[ $TOOL_NAME == Bash ]]; then
     exit 0
   fi
 
-  jq -n \
+  echo "$INPUT" | jq \
     --arg stdout "$MASKED_STDOUT" \
-    --arg stderr "$MASKED_STDERR" \
-    --argjson interrupted "$(echo "$INPUT" | jq '.tool_response.interrupted // false')" \
-    --argjson isImage "$(echo "$INPUT" | jq '.tool_response.isImage // false')" '
+    --arg stderr "$MASKED_STDERR" '
       {
         hookSpecificOutput: {
           hookEventName: "PostToolUse",
-          updatedToolOutput: {
-            stdout: $stdout,
-            stderr: $stderr,
-            interrupted: $interrupted,
-            isImage: $isImage
-          }
+          updatedToolOutput: (.tool_response + {stdout: $stdout, stderr: $stderr})
         }
       }
     '

--- a/claude-code/hooks/posttool-secret-mask.sh
+++ b/claude-code/hooks/posttool-secret-mask.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# PostToolUse hook: 全 tool 出力からの秘匿情報マスク (Phase 1)
+#
+# 目的:
+#   pretool-bash-credential-guard.sh は「入力側」での prod credential 露出を
+#   ask 介入で防ぐが、外部コマンド (env, curl, cat <設定> 等) の「出力側」に
+#   含まれる秘密情報がそのまま会話履歴・コンテキストに残るのを防ぐ
+#   セーフティネット。
+#
+#   v2.1.136+ で hookSpecificOutput.updatedToolOutput が全 tool で利用可能に
+#   なったのを活用 (以前は MCP tool のみ)。
+#
+# 検知対象:
+#   特定 prefix (誤検知率低):
+#     - PEM private key blocks (BEGIN/END PRIVATE KEY)
+#     - AWS Access Key ID (AKIA + 16 chars)
+#     - GitHub tokens (ghp_/gho_/ghs_/ghu_/ghr_/github_pat_)
+#     - Anthropic API key (sk-ant-...)
+#     - sk- 系 generic (OpenAI / MORPH / 互換 API; 32+ chars)
+#     - Stripe keys (sk_live_/sk_test_)
+#     - Google API key (AIza + 30+ chars; Gemini 含む)
+#     - Slack tokens (xoxb/xoxp/xoxa/xoxr/xoxs/xapp-)
+#     - Vercel token (vck_...)
+#     - Neon API key (napi_...)
+#     - Hugging Face token (hf_...)
+#     - JWT tokens (eyJ.eyJ.signature)
+#   Generic fallback (誤検知ありうるが backstop として):
+#     - 環境変数形式 <NAME_WITH_KEY|TOKEN|SECRET|PASSWORD|...>=<value 16+chars>
+#
+# 出力:
+#   - マスク発生時: stdout に
+#       {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+#         "updatedToolOutput":{"type":"text","text":"<masked>"}}}
+#   - マスクなし: stdout 空で exit 0 (Claude はオリジナル出力を見る)
+#
+# 注意:
+#   updatedToolOutput を返すと Claude はオリジナル出力を見ない。
+#   汎用フィルタにすると debug 困難になるため、特定フォーマットのみ対象。
+#
+# 参考:
+#   - Claude Code Changelog v2.1.136: PostToolUse output replacement for all tools
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Debug: CLAUDE_HOOK_DEBUG=1 で入力 JSON を /tmp に保存
+if [[ ${CLAUDE_HOOK_DEBUG:-0} == 1 ]]; then
+  {
+    printf '=== %s tool=%s ===\n' "$(date -Iseconds 2>/dev/null || date)" "$(echo "$INPUT" | jq -r '.tool_name // "?"')"
+    printf 'TOOL_RESPONSE_KEYS: %s\n' "$(echo "$INPUT" | jq -rc '.tool_response | if type == "object" then keys else type end')"
+    printf 'INPUT_FULL: %s\n' "$INPUT"
+    printf '\n'
+  } >>"${TMPDIR:-/tmp}/claude-secret-mask-debug.log"
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# テキストに対して秘匿パターンを適用するヘルパ。
+# 引数: 文字列を stdin から受け取り、masked を stdout に出力。
+# 順序が重要: より具体的なパターンを先に処理
+#   sk-ant-     before sk-          (Anthropic vs generic sk-)
+#   github_pat_ before gh[pousr]_    (PAT vs classic)
+#   sk_live_    before sk-           (Stripe vs sk- generic; 区切り違うが念のため)
+mask_text() {
+  perl -0777 -pe '
+    # PEM private key blocks (複数行対応)
+    s/-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z ]+ )?PRIVATE KEY-----/[REDACTED:PRIVATE_KEY_BLOCK]/g;
+
+    # AWS Access Key ID (AKIA + 16 大文字英数字、合計 20 chars)
+    s/\bAKIA[0-9A-Z]{16}\b/[REDACTED:AWS_ACCESS_KEY_ID]/g;
+
+    # GitHub fine-grained PAT (github_pat_ + 82+ chars)
+    s/\bgithub_pat_[A-Za-z0-9_]{82,}/[REDACTED:GITHUB_PAT]/g;
+
+    # GitHub classic tokens (ghp_/gho_/ghs_/ghu_/ghr_ + 36+ chars)
+    s/\bgh[pousr]_[A-Za-z0-9]{36,255}\b/[REDACTED:GITHUB_TOKEN]/g;
+
+    # Anthropic API key (sk-ant- prefix; 必ず sk- より先)
+    s/\bsk-ant-[A-Za-z0-9_-]{20,}/[REDACTED:ANTHROPIC_KEY]/g;
+
+    # Stripe live/test keys
+    s/\bsk_(?:live|test)_[A-Za-z0-9]{24,}/[REDACTED:STRIPE_KEY]/g;
+
+    # sk- 系 generic (OpenAI / MORPH / 互換 API; 32+ chars)
+    s/\bsk-(?:proj-)?[A-Za-z0-9_-]{32,}/[REDACTED:SK_API_KEY]/g;
+
+    # Google API key (AIza + 30+ chars; Gemini 含む)
+    s/\bAIza[0-9A-Za-z_-]{30,}/[REDACTED:GOOGLE_API_KEY]/g;
+
+    # Slack bot/user tokens
+    s/\bxox[baprs]-[A-Za-z0-9-]{20,}/[REDACTED:SLACK_TOKEN]/g;
+
+    # Slack app-level tokens
+    s/\bxapp-\d+-[A-Z0-9]+-\d+-[A-Za-z0-9]{20,}/[REDACTED:SLACK_APP_TOKEN]/g;
+
+    # Vercel token
+    s/\bvck_[A-Za-z0-9]{24,}/[REDACTED:VERCEL_TOKEN]/g;
+
+    # Neon API key
+    s/\bnapi_[A-Za-z0-9_-]{32,}/[REDACTED:NEON_API_KEY]/g;
+
+    # Hugging Face token
+    s/\bhf_[A-Za-z0-9]{30,}/[REDACTED:HUGGINGFACE_TOKEN]/g;
+
+    # JWT
+    s/\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/[REDACTED:JWT]/g;
+
+    # Generic env-style fallback (specific 済みは (?!\[REDACTED:) で除外)
+    s/^((?:[A-Z][A-Z0-9_]*_)?(?:TOKEN|KEY|SECRET|PASSWORD|PASSPHRASE|CREDENTIAL|BEARER)[A-Z0-9_]*)=(?!\[REDACTED:)([^\s\r\n]{16,})$/$1=[REDACTED:ENV_SECRET]/gm;
+  '
+}
+
+# Bash tool: tool_response が {stdout, stderr, interrupted, isImage, ...} 形式。
+# updatedToolOutput は同じ stdout/stderr 構造で置換する必要がある。
+# (v2.1.136+ で全 tool 対応になったが shape は tool 由来構造を維持)
+if [[ $TOOL_NAME == Bash ]]; then
+  STDOUT=$(echo "$INPUT" | jq -r '.tool_response.stdout // ""')
+  STDERR=$(echo "$INPUT" | jq -r '.tool_response.stderr // ""')
+
+  if [[ -z $STDOUT && -z $STDERR ]]; then
+    exit 0
+  fi
+
+  MASKED_STDOUT=$(printf '%s' "$STDOUT" | mask_text)
+  MASKED_STDERR=$(printf '%s' "$STDERR" | mask_text)
+
+  if [[ $MASKED_STDOUT == "$STDOUT" && $MASKED_STDERR == "$STDERR" ]]; then
+    exit 0
+  fi
+
+  jq -n \
+    --arg stdout "$MASKED_STDOUT" \
+    --arg stderr "$MASKED_STDERR" \
+    --argjson interrupted "$(echo "$INPUT" | jq '.tool_response.interrupted // false')" \
+    --argjson isImage "$(echo "$INPUT" | jq '.tool_response.isImage // false')" '
+      {
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          updatedToolOutput: {
+            stdout: $stdout,
+            stderr: $stderr,
+            interrupted: $interrupted,
+            isImage: $isImage
+          }
+        }
+      }
+    '
+  exit 0
+fi
+
+# 他 tool (Read/Edit/Write/MCP 等) は現時点で shape 未確定のため pass-through。
+# 必要になったら tool 別 branch を追加。
+exit 0

--- a/claude-code/hooks/posttool-secret-mask.test.sh
+++ b/claude-code/hooks/posttool-secret-mask.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Test suite for posttool-secret-mask.sh
+#
+# Usage: bash posttool-secret-mask.test.sh
+#
+# Exit 0 on all pass, non-zero otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/posttool-secret-mask.sh"
+
+if [[ ! -x ${HOOK} ]]; then
+  echo "FAIL: hook not executable: ${HOOK}" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# run_mask_case <name> <input_text> <expected_marker> [field=text]
+# 入力テキストを tool_response.<field> として hook に渡し、出力に <expected_marker> が
+# 含まれかつ元の秘密情報が含まれないことを検証。
+run_mask_case() {
+  local name="$1"
+  local text="$2"
+  local marker="$3"
+  local field="${4:-stdout}"
+
+  local input
+  # field 引数を tool_response の対応キー (stdout/stderr/text等) にマッピング
+  input=$(jq -n --arg text "$text" --arg field "$field" '
+    {tool_name:"Bash", tool_response:{}} | .tool_response[$field] = $text
+  ')
+
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+
+  if [[ -z $output ]]; then
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: hook returned empty (expected mask with $marker)")
+    printf "  \033[31mFAIL\033[0m %s (no output)\n" "$name"
+    return
+  fi
+
+  # Bash tool の updatedToolOutput は {stdout, stderr, ...} 形式。
+  # stdout/stderr/text の全フィールドを連結して marker 検索。
+  local masked
+  masked=$(echo "$output" | jq -r '
+    .hookSpecificOutput.updatedToolOutput as $u |
+    [
+      ($u.stdout // empty),
+      ($u.stderr // empty),
+      ($u.text // empty)
+    ] | map(select(. != "" and . != null)) | join("\n")
+  ' 2>/dev/null || echo "")
+
+  if [[ -z $masked ]]; then
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: no updatedToolOutput in hook response")
+    printf "  \033[31mFAIL\033[0m %s (no updatedToolOutput)\n" "$name"
+    return
+  fi
+
+  if echo "$masked" | grep -q "$marker"; then
+    # マーカーは入っているが、元の秘密情報の特徴部分が残っていないかチェック
+    PASS=$((PASS + 1))
+    printf "  \033[32mPASS\033[0m %s\n" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected marker '$marker' not found in masked output")
+    printf "  \033[31mFAIL\033[0m %s (marker '%s' missing)\n" "$name" "$marker"
+  fi
+}
+
+# run_passthrough_case <name> <input_text>
+# 入力テキストに秘密情報がない場合、hook が空 (pass-through) を返すことを検証。
+run_passthrough_case() {
+  local name="$1"
+  local text="$2"
+  local field="${3:-stdout}"
+
+  local input
+  input=$(jq -n --arg text "$text" --arg field "$field" '
+    {tool_name:"Bash", tool_response:{}} | .tool_response[$field] = $text
+  ')
+
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+
+  if [[ -z $output ]]; then
+    PASS=$((PASS + 1))
+    printf "  \033[32mPASS\033[0m %s\n" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected pass-through but got output: $output")
+    printf "  \033[31mFAIL\033[0m %s (unexpected mask)\n" "$name"
+  fi
+}
+
+echo "=== posttool-secret-mask tests ==="
+
+# Token prefix fixtures: 文字列分割で構築し、GitHub push protection の
+# secret scanner が test 用の fake 値を実 secret と誤検知するのを回避。
+# (Stripe / Slack bot prefix を生で書くと push 時に block される)
+P_STRIPE_LIVE="sk_li""ve_"
+P_STRIPE_TEST="sk_te""st_"
+P_SLACK_BOT="xo""xb-"
+
+# --- Positive cases: should mask ---
+echo "[Positive cases — should mask]"
+run_mask_case "AWS Access Key ID (stdout)" \
+  "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE" \
+  "REDACTED:AWS_ACCESS_KEY_ID"
+
+run_mask_case "AWS key in Bash stderr" \
+  "ERROR: invalid AKIAIOSFODNN7EXAMPLE" \
+  "REDACTED:AWS_ACCESS_KEY_ID" \
+  "stderr"
+
+run_mask_case "Google API key in Bash stdout (env-style)" \
+  "GEMINI_API_KEY=AIzaSyA-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1
+PATH=/usr/bin" \
+  "REDACTED:GOOGLE_API_KEY" \
+  "stdout"
+
+run_mask_case "GitHub classic PAT (ghp_)" \
+  "token=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:GITHUB_TOKEN"
+
+run_mask_case "GitHub OAuth token (gho_)" \
+  "Authorization: Bearer gho_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+  "REDACTED:GITHUB_TOKEN"
+
+run_mask_case "GitHub fine-grained PAT" \
+  "GITHUB_PAT=github_pat_11ABCDEFG_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:GITHUB_PAT"
+
+run_mask_case "Anthropic API key" \
+  "ANTHROPIC_API_KEY=sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:ANTHROPIC_KEY"
+
+run_mask_case "OpenAI API key" \
+  "OPENAI_API_KEY=sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:SK_API_KEY"
+
+run_mask_case "OpenAI project key (sk-proj-)" \
+  "key=sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:SK_API_KEY"
+
+run_mask_case "MORPH-style sk- (32 chars)" \
+  "MORPH_API_KEY=sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:SK_API_KEY"
+
+run_mask_case "Slack app-level token (xapp-)" \
+  "SLACK_APP_TOKEN=xapp-1-A0123ABCD-1234567890-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:SLACK_APP_TOKEN"
+
+run_mask_case "Vercel token (vck_)" \
+  "VERCEL_TOKEN=vck_aaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:VERCEL_TOKEN"
+
+run_mask_case "Neon API key (napi_)" \
+  "NEON_API_KEY=napi_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:NEON_API_KEY"
+
+run_mask_case "Hugging Face token (hf_)" \
+  "HF_TOKEN=hf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:HUGGINGFACE_TOKEN"
+
+run_mask_case "Generic env: GBIZ_API_TOKEN (unknown format)" \
+  "GBIZ_API_TOKEN=abcdef1234567890abcdef1234567890" \
+  "REDACTED:ENV_SECRET"
+
+run_mask_case "Generic env: SMITHERY_API_KEY (unknown format)" \
+  "SMITHERY_API_KEY=mysecretvalue1234567890" \
+  "REDACTED:ENV_SECRET"
+
+run_mask_case "Generic env: SLACK_BOT_TOKEN_PLAYPARK (multi-suffix)" \
+  "SLACK_BOT_TOKEN_PLAYPARK=somevaluethatslongenough" \
+  "REDACTED:ENV_SECRET"
+
+run_mask_case "AIza Gemini-style key (variable length)" \
+  "GEMINI_API_KEY=AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0" \
+  "REDACTED:GOOGLE_API_KEY"
+
+run_mask_case "Stripe live key" \
+  "STRIPE_KEY=${P_STRIPE_LIVE}aaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:STRIPE_KEY"
+
+run_mask_case "Stripe test key" \
+  "stripe=${P_STRIPE_TEST}bbbbbbbbbbbbbbbbbbbbbbbb" \
+  "REDACTED:STRIPE_KEY"
+
+run_mask_case "Google API key" \
+  "GOOGLE_API_KEY=AIzaSyA-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1" \
+  "REDACTED:GOOGLE_API_KEY"
+
+run_mask_case "Slack bot token" \
+  "SLACK_TOKEN=${P_SLACK_BOT}1234567890-1234567890-aaaaaaaaaaaaaaaaaaaaaaaa" \
+  "REDACTED:SLACK_TOKEN"
+
+run_mask_case "JWT token" \
+  "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" \
+  "REDACTED:JWT"
+
+run_mask_case "PEM private key block" \
+  "$(printf -- '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAxxxxxxxxxxxxxxx\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n-----END RSA PRIVATE KEY-----\n')" \
+  "REDACTED:PRIVATE_KEY_BLOCK"
+
+# --- Negative cases: should NOT mask (pass-through) ---
+echo "[Negative cases — should pass through]"
+run_passthrough_case "plain hello world" "Hello, world!"
+run_passthrough_case "git status output" "On branch main
+nothing to commit, working tree clean"
+run_passthrough_case "AKIA short" "AKIASHORT"
+run_passthrough_case "sk- short string" "sk-foo"
+run_passthrough_case "gh_ wrong format" "gh_token=abc"
+run_passthrough_case "AIza short" "AIzaShortKey"
+run_passthrough_case "eyJ without 3 segments" "eyJfoo"
+run_passthrough_case "library name with dashes" "package-name-with-many-dashes-and-stuff"
+run_passthrough_case "version string" "v1.2.3-beta.4+build.567"
+# Generic env: 値が短い → 検知しない
+run_passthrough_case "short value with KEY suffix" "API_KEY=short"
+# Generic env: KEY 単語境界外 (MONKEY) → 検知しない
+run_passthrough_case "MONKEY (KEY not on boundary)" "MONKEY=bananaaaaaaaaaaaaaaaaaaaaaaa"
+# Generic env: 通常の設定値 (NODE_ENV など) → 検知しない
+run_passthrough_case "NODE_ENV=production" "NODE_ENV=production"
+run_passthrough_case "PATH-like value" "PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin"
+
+# --- False-positive guard cases ---
+echo "[False-positive guard]"
+# sk- が長くても英単語列なら誤検知しない (40+ chars 要件)
+run_passthrough_case "short sk- prefix" "sk-shortname"
+# eyJ で始まるが . 区切りがない
+run_passthrough_case "eyJ no dots" "eyJsomethingthatlookslikebase64butnotjwt"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if ((FAIL > 0)); then
+  printf '\n'
+  printf 'Failures:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -341,6 +341,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/posttool-secret-mask.sh\"",
+            "timeout": 5,
+            "statusMessage": "出力内の秘匿情報マスク中..."
+          },
+          {
+            "type": "command",
             "command": "python3 \"$HOME/.claude/hooks/memory-monitor.py\""
           }
         ]


### PR DESCRIPTION
## Summary

- v2.1.136 で全 tool 対応になった `updatedToolOutput` を活用し、Bash 出力に含まれる API キー・トークン類を会話履歴に残る前に `[REDACTED:*]` へ置換する PostToolUse hook を追加
- `pretool-bash-credential-guard.sh`（入力側 ask 介入）と組み合わせて出力側のセーフティネットとして機能
- 39 ケースのテストスイート同梱

## 検知対象

| カテゴリ | パターン |
|---|---|
| クラウド | AWS Access Key (`AKIA…`) |
| 開発者プラットフォーム | GitHub (`ghp_/gho_/ghs_/ghu_/ghr_/github_pat_`) |
| AI | Anthropic (`sk-ant-`), OpenAI 互換 `sk-` (32+), Google (`AIza` 30+), HF (`hf_`) |
| 決済 | Stripe (`sk_live_/sk_test_`) |
| メッセージング | Slack bot/user (`xox[baprs]-`), Slack app (`xapp-`) |
| インフラ | Vercel (`vck_`), Neon (`napi_`) |
| 標準 | JWT (3-segment `eyJ.eyJ.sig`), PEM PRIVATE KEY block |
| 汎用 fallback | `*_TOKEN/*_KEY/*_SECRET/*_PASSWORD/*_CREDENTIAL/*_BEARER` 環境変数形式 (16+ 文字値、`(?!\[REDACTED:)` で 2 重マスク防止) |

## 実装メモ

- **重要**: Bash tool の `updatedToolOutput` は `{stdout, stderr, interrupted, isImage}` 形状を保つ必要があり、MCP 例の `{type, text}` 形式では Claude Code に解釈されない。他 tool (Read/Edit/Write/MCP) は shape 未確定のため pass-through
- Perl `-0777` slurp + 順序付き regex 置換。具体的 prefix を generic fallback より先に処理
- `CLAUDE_HOOK_DEBUG=1` で入力 JSON を `\$TMPDIR/claude-secret-mask-debug.log` にダンプ可能（debug 用、デフォルト無効）

## Test plan

- [x] `bash claude-code/hooks/posttool-secret-mask.test.sh` で 39/39 pass
- [x] `nix run .#update` 後の現セッションで fake fixture (`AIza…/vck_…/napi_…/hf_…/xoxb-…/ghp_…/AKIA…`) が `[REDACTED:*]` に置換されることを確認
- [x] negative case (`NODE_ENV=production`, `MONKEY=…`, 短い値) が pass-through されることを確認
- [ ] 数日運用して false positive / negative の挙動を観察