### PR TITLE
chore(flake): direnv overlay を削除 (cache.nixos.org にバイナリ追加済み)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,14 +49,6 @@
         system:
         import nixpkgs {
           inherit system;
-          overlays = [
-            # direnv の checkPhase は macOS Nix サンドボックス内でハングするため無効化
-            (_final: prev: {
-              direnv = prev.direnv.overrideAttrs (_: {
-                doCheck = false;
-              });
-            })
-          ];
         }
       );
 


### PR DESCRIPTION
## 背景

commit fd84774 で以下の overlay を追加しました:

```nix
# direnv の checkPhase は macOS Nix サンドボックス内でハングするため無効化
(_final: prev: {
  direnv = prev.direnv.overrideAttrs (_: { doCheck = false; });
})
```

原因: 2026-04-28 時点で direnv 2.37.1 の aarch64-darwin バイナリが cache.nixos.org に存在せず、ソースビルドが走り、macOS Nix サンドボックス内で zsh checkPhase がハング。

## 検証結果

| 項目 | 結果 |
|------|------|
| nixpkgs rev (flake.lock) | `549bd84d6279f9852cae6225e372cc67fb91a4c1` |
| direnv バージョン | 2.37.1 |
| nixos-unstable チャンネル rev | `549bd84d6279f9852cae6225e372cc67fb91a4c1` (一致 ✅) |
| Hydra build (aarch64-darwin) | `buildstatus: 0` (成功 ✅) |
| store path | `/nix/store/nb9y6wsva2qmjz7a7ci6nm0m5n9f4814-direnv-2.37.1` |
| cache.nixos.org narinfo | HTTP 200 ✅ |

`https://cache.nixos.org/nb9y6wsva2qmjz7a7ci6nm0m5n9f4814.narinfo` が HTTP 200 を返すことを確認。バイナリは Nix sandbox 外で Hydra がビルド済みのため、`nix run .#update` 実行時はキャッシュから直接ダウンロードされ、checkPhase は実行されない。

## Test plan

- [ ] macOS (aarch64-darwin) で `nix run .#update` を実行し、direnv のソースビルドが走らずビルドが完走することを確認
- [ ] ビルドログに `direnv-2.37.1` のコンパイル出力が出ないことを確認（= キャッシュヒット）

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjoC8UnQEmNFr3zwQUhJb9)_