### PR TITLE
feat(flake): hermes-agent 用 Docker image output + cli-packages.nix 切り出し (#55)

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -103,6 +103,15 @@ in
     trusted-users = [ "@admin" ]; # 管理者ユーザーを信頼
   };
 
+  # Linux builder（macOS 上で linux 用 derivation を build する VM）
+  # hermes-agent 用 Docker image (dockerTools.buildLayeredImage) は Linux 専用のため
+  # darwin から build するには linux-builder が必須。
+  # ephemeral = true により VM は必要時のみ起動しリソース消費を抑える。
+  nix.linux-builder = {
+    enable = true;
+    ephemeral = true;
+  };
+
   # シェルの有効化設定
   programs.fish.enable = true; # デフォルトシェルとしてfishを有効化
   programs.zsh.enable = false; # zshは無効化

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,52 @@
         }
       ) { } usernames;
 
+      # hermes-agent 用 Docker image を含む packages 出力（各システム向け）
+      # linux-* システムのみ hermes-image を生成（dockerTools は Linux 専用）。
+      # darwin 上では nix.linux-builder 経由で aarch64-linux 用 image を build できる。
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+          cliPackages = import ./lib/cli-packages.nix {
+            inherit pkgs;
+            mode = "container";
+          };
+        in
+        nixpkgs.lib.optionalAttrs (nixpkgs.lib.hasSuffix "-linux" system) {
+          hermes-image = pkgs.dockerTools.buildLayeredImage {
+            name = "hermes-tools";
+            tag = "latest";
+            contents =
+              cliPackages
+              ++ (with pkgs; [
+                bashInteractive
+                cacert
+                dockerTools.fakeNss
+                findutils
+                gawk
+                gnugrep
+                gnused
+                gnutar
+                gzip
+                iana-etc
+                less
+                shadow
+              ]);
+            config = {
+              Cmd = [ "${pkgs.bashInteractive}/bin/bash" ];
+              WorkingDir = "/workspace";
+              Env = [
+                "PATH=/bin:/usr/bin"
+                "LANG=C.UTF-8"
+                "LC_ALL=C.UTF-8"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+            };
+          };
+        }
+      );
+
       # 一括アップデート用のスクリプトを定義（各システム向け）
       apps = forAllSystems (system: {
         update = {
@@ -216,6 +262,45 @@
               fi
 
               echo "All updates complete!"
+            ''
+          );
+        };
+
+        # hermes-agent 用 Docker image を build して docker load まで一括実行
+        # darwin host では nix.linux-builder 経由で aarch64-linux 用 image を build する
+        "hermes-image-load" = {
+          type = "app";
+          program = toString (
+            nixpkgsFor.${system}.writeShellScript "hermes-image-load" ''
+              set -e
+
+              # build 対象システムを決定
+              # - darwin host: aarch64-linux (linux-builder 経由)
+              # - linux host: 現在のシステム
+              if [[ "$(uname)" == "Darwin" ]]; then
+                TARGET_SYSTEM="aarch64-linux"
+              else
+                ARCH=$(uname -m)
+                if [[ "$ARCH" == "x86_64" ]]; then
+                  TARGET_SYSTEM="x86_64-linux"
+                elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+                  TARGET_SYSTEM="aarch64-linux"
+                else
+                  echo "Unsupported architecture: $ARCH"
+                  exit 1
+                fi
+              fi
+
+              echo "Building hermes-image for $TARGET_SYSTEM..."
+              IMAGE_PATH=$(nix build --no-link --print-out-paths ".#packages.''${TARGET_SYSTEM}.hermes-image")
+
+              echo "Loading $IMAGE_PATH into docker..."
+              docker load < "$IMAGE_PATH"
+
+              echo "Done. Image available as: hermes-tools:latest"
+              echo ""
+              echo "Test with:"
+              echo "  docker run --rm hermes-tools:latest /bin/bash -c \"gh --version && git --version && vips --version\""
             ''
           );
         };

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -7,6 +7,14 @@
 }:
 let
   packages = import ../../common/packages.nix { inherit pkgs; };
+  # CLI tool 一覧は lib/cli-packages.nix に集約 (mode=host で hostOnly 込みのフルセット)
+  # hermes-agent 用 container image (mode=container) と単一ソースを共有する。
+  cliPackages = import ../../lib/cli-packages.nix {
+    inherit pkgs;
+    mode = "host";
+    # 注: cliPackages の common には commonPackages と重複する coreutils/curl/git を含む。
+    # Nix store の dedup によりインストール上の重複は発生しない (behavior-preserving)。
+  };
 in
 {
   home = {
@@ -18,45 +26,8 @@ in
     ];
     stateVersion = "24.05"; # Please read the comment before changing.
 
-    # 共通パッケージを全プラットフォームでインストール
-    packages =
-      packages.commonPackages
-      ++ (with pkgs; [
-        act
-        bat
-        bun
-        python313Packages.deepl
-        eza
-        fastfetch
-        fd
-        ffmpeg
-        flyctl
-        fzf
-        gh
-        ghq
-        jq
-        lazygit
-        mariadb
-        marp-cli
-        mise
-        ollama
-        opentofu
-        postgresql_17
-        procs
-        rclone
-        rip2
-        ripgrep
-        ripgrep-all
-        sd
-        starship
-        stripe-cli
-        tbls
-        tldr
-        turso-cli
-        vips
-        zellij
-        zoxide
-      ]);
+    # 共通パッケージ + CLI tool 群 (host モード)
+    packages = packages.commonPackages ++ cliPackages;
 
     file = {
       ".myclirc".source = ./file/.myclirc;

--- a/lib/cli-packages.nix
+++ b/lib/cli-packages.nix
@@ -1,0 +1,68 @@
+# CLI tool 一覧の単一ソース化
+#
+# mode = "host"      → 開発マシン用フルセット (host common + host-only)
+# mode = "container" → hermes-agent 用 Docker image 向けの最小セット (host common のみ)
+#
+# 使用例:
+#   home-manager/home/default.nix:
+#     cliPackages = import ../../lib/cli-packages.nix { inherit pkgs; mode = "host"; };
+#
+#   flake.nix (dockerTools.buildLayeredImage):
+#     cliPackages = import ./lib/cli-packages.nix { inherit pkgs; mode = "container"; };
+{
+  pkgs,
+  mode ? "host",
+}:
+
+let
+  # 共通 (host / container 両方)
+  common = with pkgs; [
+    bat
+    bun
+    coreutils
+    curl
+    eza
+    fd
+    fzf
+    gh
+    ghq
+    git
+    jq
+    lazygit
+    mise
+    rip2
+    ripgrep
+    ripgrep-all
+    sd
+    starship
+    stripe-cli
+    tldr
+    turso-cli
+    vips
+    zellij
+    zoxide
+  ];
+
+  # host のみ (開発マシン専用、container には不要)
+  hostOnly = with pkgs; [
+    act
+    fastfetch
+    ffmpeg
+    flyctl
+    mariadb
+    marp-cli
+    ollama
+    opentofu
+    postgresql_17
+    procs
+    python313Packages.deepl
+    rclone
+    tbls
+  ];
+in
+if mode == "host" then
+  common ++ hostOnly
+else if mode == "container" then
+  common
+else
+  throw "cli-packages.nix: unknown mode '${mode}', expected 'host' or 'container'"


### PR DESCRIPTION
Closes #55

## 概要

hermes-agent ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)) を Mac Studio 上の Docker container で運用するため、Nix flake から host/container 用 CLI package set を単一ソースで供給できるようにする。

Issue 本体の段階分け実装計画に従い、additive な変更（Phase 2/3）を先に行い、destructive な変更（Phase 1/4）はそれぞれ独立 commit に分離した。

## 変更内容

| Commit | 種別 | 概要 |
|--------|------|------|
| `12833c0` | additive | `lib/cli-packages.nix` 新規追加。`mode = "host" \| "container"` で振り分ける関数を export |
| `9a6b61c` | additive | `flake.nix` に `packages.<linux-system>.hermes-image` (dockerTools.buildLayeredImage) と `apps.<system>.hermes-image-load` を追加 |
| `f5c18a8` | destructive (単独) | `darwin/default.nix` に `nix.linux-builder = { enable = true; ephemeral = true; }` を追加 |
| `a32ec5b` | destructive (単独) | `home-manager/home/default.nix` の inline package list を `lib/cli-packages.nix { mode = "host"; }` 参照に refactor |

### `lib/cli-packages.nix` の振り分け

- **common (host/container 両方)**: bat, bun, coreutils, curl, eza, fd, fzf, gh, ghq, git, jq, lazygit, mise, rip2, ripgrep, ripgrep-all, sd, starship, stripe-cli, tldr, turso-cli, vips, zellij, zoxide
- **host のみ**: act, fastfetch, ffmpeg, flyctl, mariadb, marp-cli, ollama, opentofu, postgresql_17, procs, python313Packages.deepl, rclone, tbls

### `hermes-image` の構成

- ベース: `dockerTools.buildLayeredImage` で `hermes-tools:latest` を生成
- 含めるもの: `cli-packages.nix { mode = "container"; }` + 必須 OS パッケージ (`bashInteractive`, `cacert`, `dockerTools.fakeNss`, `findutils`, `gawk`, `gnugrep`, `gnused`, `gnutar`, `gzip`, `iana-etc`, `less`, `shadow`)
- 設定: `WorkingDir = "/workspace"`, `Cmd = bash`, `SSL_CERT_FILE` を `cacert` に設定 (TLS root CA 対応), `LANG/LC_ALL=C.UTF-8`

事故ポイント inventory の以下を対策済み:
- #4: `dockerTools.fakeNss` で `/etc/passwd` 不在対策
- #5: `cacert` + `SSL_CERT_FILE` で TLS root CA 対策
- #11: `linux-builder.ephemeral = true` で VM の常時起動を回避

## 検証

### このリポジトリ上で実施済み

- [x] **Phase 0**: `nix eval --raw nixpkgs#legacyPackages.aarch64-linux.{vips,gh,python313Packages.deepl}.name` → 全て解決確認 (vips-8.18.2 / gh-2.92.0 / python3.13-deepl-1.27.0)
- [x] **各 Phase 後 `nix flake check`**: 全 pass (formatting check 含む)
- [x] **`nix eval .#packages.aarch64-linux.hermes-image.drvPath`**: derivation 評価成功 (`hermes-tools.tar.gz.drv`)
- [x] **Phase 4 後 behavior-preserving 確認**: `nix build .#homeConfigurations.naramotoyuuji-darwin.activationPackage` を refactor 前後で実施し、`nix store diff-closures` の出力が空（package set 不変、wrapper derivation の hash 変化のみ）であることを確認

### マージ後に開発者環境で必要な手動検証

```bash
# 1. linux-builder を有効化（destructive）
sudo darwin-rebuild switch --flake .#MyMBP-naramotoyuuji

# 動作確認: linux 用 derivation が build できることを確認
nix build nixpkgs#hello --system aarch64-linux

# 2. hermes-image を build + docker load
nix run .#hermes-image-load

# 3. container 内で CLI tool が動作することを確認
docker run --rm hermes-tools:latest /bin/bash -c "gh --version && git --version && vips --version"

# 4. home-manager refactor 反映（behavior-preserving なので新規 install/removal なし）
nix run .#update
```

各ステップでの rollback:
- `darwin-rebuild rollback` (Phase 1 commit `f5c18a8` の取り消し)
- `home-manager generations` から 1 つ前を activate (Phase 4 commit `a32ec5b` の取り消し)

## 対象外 / 別 issue

- hermes 側の `~/.hermes/config.yaml` 設定（別 issue / 別 repo）
- `:latest` 以外の image tag 運用（将来必要なら日付タグへ移行）
- container 内 `mise` 動作（方針: container には mise を含めず、必要なランタイムは直接 contents で）

## 関連

- hermes-agent docs: https://hermes-agent.nousresearch.com/docs/user-guide/security
- nix-darwin linux-builder: https://nixcademy.com/posts/macos-linux-builder/