### PR TITLE
feat(hermes): hermes-agent 初期構築 (config + plugin + activation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ codex/config.local.toml
 codex/*.local.toml
 codex/**/*.local.toml
 
+# Hermes - sensitive runtime data
+# 正規ファイル: hermes/.env.template は tracked、実体 .env は commit しない
+hermes/.env
+hermes/**/__pycache__/
+
 # Sensitive authentication files (global)
 **/auth-profiles.json
 **/*.credentials.json

--- a/hermes/.env.template
+++ b/hermes/.env.template
@@ -1,0 +1,19 @@
+# hermes/.env.template — copy to ~/.hermes/.env on first activation
+# NEVER commit ~/.hermes/.env (tracked by .gitignore on the canonical hermes/.env)
+
+# Provider: OpenRouter (model: Kimi K2.6, set via `hermes model`)
+OPENROUTER_API_KEY=
+
+# Slack gateway
+SLACK_BOT_TOKEN=                  # xoxb-...
+SLACK_APP_TOKEN=                  # xapp-... (Socket Mode)
+SLACK_ALLOWED_USERS=              # yuji の Member ID (Slack profile → Copy member ID)
+SLACK_HOME_CHANNEL=               # hermes-private 等の専用 channel ID
+SLACK_REQUIRE_MENTION=true
+
+# Authorization defaults (explicit)
+GATEWAY_ALLOW_ALL_USERS=false
+
+# Git identity (forwarded into Docker container)
+GIT_AUTHOR_NAME=yuji naramoto
+GIT_AUTHOR_EMAIL=yuji.naramoto@playpark.work

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,0 +1,101 @@
+# hermes
+
+dotfiles-managed configuration for [hermes-agent](https://hermes-agent.nousresearch.com/).
+home-manager の activation により `~/.hermes/` 配下に symlink される (Plan A)。
+
+## ファイル構成
+
+```
+hermes/
+├── README.md              # このファイル
+├── config.yaml            # symlink → ~/.hermes/config.yaml
+├── .env.template          # 初回 copy → ~/.hermes/.env (chmod 600)
+└── plugins/
+    └── path_guard/        # symlink → ~/.hermes/plugins/path_guard
+        ├── plugin.yaml
+        └── __init__.py
+```
+
+`hermes/.env` は **.gitignore で除外**。tokens を含む実体ファイルは絶対に commit しない。
+
+## activation
+
+`home-manager/home/default.nix` の `activation.setupHermes` が以下を実施する:
+
+1. `~/.hermes/` ディレクトリ作成
+2. `config.yaml` を symlink (既存実体ファイルは事前削除)
+3. `plugins/*/` を per-plugin で symlink
+4. `~/.hermes/.env` が **未存在** の場合のみ `.env.template` から copy + chmod 600
+   - 既存の `.env` は tokens 喪失防止のため触らない
+
+適用は通常通り:
+
+```bash
+nix run .#update
+```
+
+## 運用メモ
+
+### tokens 投入 (初回のみ)
+
+`nix run .#update` 後に `~/.hermes/.env` が作成される (template 由来)。
+以下を手動入力:
+
+| 変数 | 取得元 |
+|------|--------|
+| `OPENROUTER_API_KEY` | https://openrouter.ai/keys |
+| `SLACK_BOT_TOKEN` (xoxb-) | Slack App → OAuth & Permissions |
+| `SLACK_APP_TOKEN` (xapp-) | Slack App → Basic Information → App-Level Tokens (`connections:write`) |
+| `SLACK_ALLOWED_USERS` | Slack profile → Copy member ID |
+| `SLACK_HOME_CHANNEL` | 専用 channel ID |
+
+`chmod 600 ~/.hermes/.env` は activation で実施済み。
+
+### model 切替
+
+```bash
+hermes model
+# Provider: OpenRouter
+# Model: moonshotai/kimi-k2.6 など
+```
+
+### Slack manifest 生成
+
+```bash
+hermes slack manifest --write
+# ~/.hermes/slack-manifest.json が生成される
+# → Slack App 管理画面で "From a manifest" → import
+```
+
+### 起動
+
+```bash
+hermes gateway   # foreground
+```
+
+## path_guard plugin
+
+hermes built-in approvals が見落とす deny を補強する。
+
+- **sensitive path**: `.env` / `.ssh/` / `.gnupg/` / `.aws/` / `Library/Keychains/` 等
+- **interpreter/runner**: `npx` / `uvx` / `bunx` / `deno run|eval` / `eval ` / `fish|dash -c`
+
+`pre_tool_call` フックで `tool_name` / `args.command|path|file_path|paths` を走査し、
+マッチしたら `{"action": "block", ...}` を返す。
+
+## Rollback
+
+```bash
+git revert <commit>
+nix run .#update
+# 必要なら
+rm -rf ~/.hermes/{config.yaml,plugins/path_guard}
+```
+
+## 参考
+
+- [hermes-agent docs](https://hermes-agent.nousresearch.com/docs/)
+- [Slack gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack)
+- [Security guide](https://hermes-agent.nousresearch.com/docs/user-guide/security)
+- 前段 issue: [#55](https://github.com/it-all-playpark/dotfiles/issues/55) — hermes-tools docker image
+- 親 issue: [#57](https://github.com/it-all-playpark/dotfiles/issues/57)

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -1,0 +1,48 @@
+approvals:
+  mode: smart
+  timeout: 60
+  cron_mode: deny
+
+security:
+  redact_secrets: true
+  tirith_enabled: true
+  tirith_fail_open: false
+  website_blocklist:
+    enabled: true
+    domains:
+      - "169.254.169.254"
+      - "metadata.google.internal"
+      - "fd00:ec2::254"
+
+skills:
+  guard_agent_created: true   # Q4 対策: agent 自己生成 skill の guard 必須
+
+terminal:
+  backend: docker
+  docker_image: "hermes-tools:latest"   # #55 で build
+  container_persistent: false
+  container_memory: 4096
+  docker_forward_env:
+    - "GIT_AUTHOR_NAME"
+    - "GIT_AUTHOR_EMAIL"
+    - "GH_TOKEN"
+  docker_volumes:
+    - "/Users/naramotoyuuji/ghq:/workspace/repos:ro"
+    - "/Users/naramotoyuuji/Documents/hermes-out:/workspace/out:rw"
+
+agent:
+  disabled_toolsets: []
+
+file_read_max_chars: 100000
+tool_output:
+  max_bytes: 50000
+  max_lines: 2000
+  max_line_length: 2000
+
+platforms:
+  slack:
+    reply_to_mode: "first"
+    extra:
+      reply_in_thread: true
+      reply_broadcast: false
+      strict_mention: false

--- a/hermes/plugins/path_guard/__init__.py
+++ b/hermes/plugins/path_guard/__init__.py
@@ -1,0 +1,55 @@
+import re
+
+SENSITIVE_PATH_PATTERNS = [
+    re.compile(r"(^|[/\s'\"])\.env(\.\w+)?(\s|$|['\"])"),
+    re.compile(r"\.ssh/"),
+    re.compile(r"\.gnupg/"),
+    re.compile(r"\.aws/"),
+    re.compile(r"\.config/gh/"),
+    re.compile(r"Library/Keychains/"),
+    re.compile(r"/Users/[^/]+/\.(env|ssh|gnupg|aws)"),
+]
+
+# hermes built-in approvals が見落とすパターンのみ追加
+# (python -c / node -e / bash -c / heredoc 等は built-in でカバー済み)
+INTERPRETER_DENY_PATTERNS = [
+    re.compile(r"\b(npx|pnpx|uvx|bunx)\b"),
+    re.compile(r"\bdeno\s+(run|eval)\b"),
+    re.compile(r"\beval\s+"),
+    re.compile(r"\b(fish|dash)\s+-[^\s]*c\b"),
+]
+
+
+def _block_if_sensitive(tool_name, args, **_):
+    args = args or {}
+    haystack = " ".join(
+        [
+            str(args.get("command", "")),
+            str(args.get("path", "")),
+            str(args.get("file_path", "")),
+            str(args.get("paths", "")),
+        ]
+    )
+    if not haystack.strip():
+        return None
+
+    for pat in SENSITIVE_PATH_PATTERNS:
+        if pat.search(haystack):
+            return {
+                "action": "block",
+                "message": f"path_guard: sensitive path denied ({pat.pattern})",
+            }
+
+    if tool_name == "terminal":
+        for pat in INTERPRETER_DENY_PATTERNS:
+            if pat.search(haystack):
+                return {
+                    "action": "block",
+                    "message": f"path_guard: interpreter/runner not allowed ({pat.pattern})",
+                }
+
+    return None
+
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", _block_if_sensitive)

--- a/hermes/plugins/path_guard/plugin.yaml
+++ b/hermes/plugins/path_guard/plugin.yaml
@@ -1,0 +1,3 @@
+name: path_guard
+version: 1.0.0
+description: Block sensitive host path access + interpreter/runner bypass not covered by hermes built-in approvals

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -290,6 +290,44 @@ in
       mv "$tmp_config" "$CODEX_DIR/config.toml"
       chmod 600 "$CODEX_DIR/config.toml"
     '';
+
+    # Hermes-agent 設定を dotfiles/hermes/ からシンボリックリンクで参照
+    # - config.yaml と plugins/* は symlink (上書き不可ファイルは事前削除)
+    # - .env は初回のみ template から copy。既存があれば tokens 保護のため触らない
+    activation.setupHermes = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      DOTFILES_HERMES="${config.home.homeDirectory}/ghq/github.com/it-all-playpark/dotfiles/hermes"
+      HERMES_DIR="${config.home.homeDirectory}/.hermes"
+
+      if [ ! -d "$DOTFILES_HERMES" ]; then
+        echo "Warning: $DOTFILES_HERMES does not exist. Skipping hermes setup."
+        exit 0
+      fi
+
+      mkdir -p "$HERMES_DIR/plugins"
+
+      # config.yaml — symlink (上書き不可ファイルは事前削除)
+      if [ -f "$HERMES_DIR/config.yaml" ] && [ ! -L "$HERMES_DIR/config.yaml" ]; then
+        rm "$HERMES_DIR/config.yaml"
+      fi
+      ln -sf "$DOTFILES_HERMES/config.yaml" "$HERMES_DIR/config.yaml"
+
+      # plugins — 各 plugin ディレクトリを symlink
+      for plugin_dir in "$DOTFILES_HERMES/plugins/"*/; do
+        [ -d "$plugin_dir" ] || continue
+        plugin_name="$(basename "$plugin_dir")"
+        if [ -e "$HERMES_DIR/plugins/$plugin_name" ] && [ ! -L "$HERMES_DIR/plugins/$plugin_name" ]; then
+          rm -rf "$HERMES_DIR/plugins/$plugin_name"
+        fi
+        ln -sf "$plugin_dir" "$HERMES_DIR/plugins/$plugin_name"
+      done
+
+      # .env — 初回のみ copy。既存があれば触らない (tokens 保持のため)
+      if [ ! -f "$HERMES_DIR/.env" ]; then
+        cp "$DOTFILES_HERMES/.env.template" "$HERMES_DIR/.env"
+        chmod 600 "$HERMES_DIR/.env"
+        echo "hermes: created ~/.hermes/.env from template — fill in tokens before running"
+      fi
+    '';
   };
 
   # Ollama サーバーをログイン時に自動起動


### PR DESCRIPTION
## 概要

Issue #57 の **Phase 6: hermes 設定を dotfiles repo に配置 (additive)** を実装。
dotfiles repo に `hermes/` ディレクトリを切り、home-manager の activation で
`~/.hermes/` に symlink する Plan A 方式。

## 変更内容

| ファイル | 目的 |
|----------|------|
| `.gitignore` | `hermes/.env` を ignore (secrets 誤 commit 防止) + `__pycache__` 対策 |
| `hermes/config.yaml` | hermes-agent 設定 (smart approvals / tirith / website blocklist / docker terminal backend / slack `reply_in_thread`) |
| `hermes/.env.template` | OpenRouter API key + Slack token の placeholder |
| `hermes/plugins/path_guard/plugin.yaml` | plugin metadata |
| `hermes/plugins/path_guard/__init__.py` | hermes built-in approvals が見落とす sensitive path (.env / .ssh / .aws 等) と interpreter runner (npx / uvx / deno run 等) を補強する `pre_tool_call` hook |
| `hermes/README.md` | 運用メモ (tokens 投入手順 / model 切替 / Slack manifest / rollback) |
| `home-manager/home/default.nix` | `activation.setupHermes` 追加。`config.yaml` と `plugins/*` は symlink、`.env` は **初回のみ** template から copy + `chmod 600` (既存 tokens 保護) |

## 実装順序のポイント

事故ポイント #3 (secrets 漏洩) を最優先し、`.gitignore` 更新を最初に実施。
事故ポイント #2 (既存設定喪失) は activation の `if [ ! -f "$HERMES_DIR/.env" ]`
ガードで対処。

## スコープ外 (本 PR では実施しない)

Issue 本文の以下 Phase は yuji の手動作業 / 実機検証のため、本 PR の対象外:

- **Phase 7**: workspace 準備 (`~/Documents/hermes-out` 作成、docker volume 疎通)
- **Phase 8**: Slack app setup / OpenRouter API key 発行 / `hermes gateway` 初回起動
- **Phase 9**: セキュリティ verify (Slack 経由の攻撃シナリオ実機検証)

## 検証

- [x] `nix fmt` 適用 (treefmt)
- [x] `nix flake check` all passed
- [x] `python3 -m py_compile hermes/plugins/path_guard/__init__.py` OK
- [ ] `nix run .#update` で symlink 反映 (マージ後に yuji が実施)
- [ ] `ls -la ~/.hermes/config.yaml` で symlink 確認 (マージ後)
- [ ] `stat -f %A ~/.hermes/.env` で 600 確認 (マージ後)

## Rollback

`git revert <commit>` → `nix run .#update` → 必要なら
`rm -rf ~/.hermes/{config.yaml,plugins/path_guard}`

## 関連

- Refs: #55 (hermes-tools docker image — Phase 6 の前提条件)
- Closes: #57