### PR TITLE
feat(hermes): launchd agent で gateway を自動起動

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -91,6 +91,27 @@ hermes slack manifest --write
 
 ### 起動
 
+ログイン時に **launchd agent (`com.playpark.hermes-gateway`)** が `hermes gateway`
+を background 起動する。`nix run .#update` で plist が `~/Library/LaunchAgents/`
+に展開され、即座に load される。
+
+```bash
+# 状態確認
+launchctl list | grep hermes-gateway
+
+# 停止/再開
+launchctl unload ~/Library/LaunchAgents/com.playpark.hermes-gateway.plist
+launchctl load   ~/Library/LaunchAgents/com.playpark.hermes-gateway.plist
+
+# ログ
+tail -f ~/.hermes/logs/gateway.{out,err}.log
+```
+
+KeepAlive (Crashed + 非0 exit) + `ThrottleInterval=30` を設定済みなので、
+Docker Desktop が遅れて起動するケースや一時的な network 断は自動で復旧する。
+
+foreground で debug したい場合は agent を unload してから:
+
 ```bash
 hermes gateway   # foreground
 ```

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -95,6 +95,23 @@ hermes slack manifest --write
 を background 起動する。`nix run .#update` で plist が `~/Library/LaunchAgents/`
 に展開され、即座に load される。
 
+ただし **opt-in marker `~/.hermes/.gateway-primary` が存在する host でのみ実起動** する。
+marker 不在なら agent は exit 0 で即終了し restart しない。同一 user account を
+複数 Mac で運用する場合の二重起動 (Slack に同一 App Token で multi-connect → 二重応答)
+を防ぐため。
+
+```bash
+# primary 機で opt-in
+touch ~/.hermes/.gateway-primary
+launchctl kickstart -k gui/$(id -u)/com.playpark.hermes-gateway
+
+# primary を別 Mac に移すとき
+rm ~/.hermes/.gateway-primary    # 旧機
+# 旧機の gateway を停止
+launchctl kickstart -k gui/$(id -u)/com.playpark.hermes-gateway
+# 新機で touch + kickstart
+```
+
 ```bash
 # 状態確認
 launchctl list | grep hermes-gateway

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -343,7 +343,12 @@ in
   };
 
   # hermes gateway をログイン時に自動起動 (macOS 限定)
-  # Docker Desktop が未起動でも KeepAlive + ThrottleInterval で復旧するまで再試行
+  # Docker Desktop が未起動でも KeepAlive + ThrottleInterval で復旧するまで再試行。
+  #
+  # 同一 user account を複数 Mac で運用する場合の二重起動防止:
+  # opt-in marker `~/.hermes/.gateway-primary` が存在する host でだけ実際に起動する。
+  # marker 不在なら exit 0 で終了 (KeepAlive.SuccessfulExit=false なので restart しない)。
+  # 切り替え時は旧機で `rm`、新機で `touch` + `launchctl kickstart -k gui/$(id -u)/com.playpark.hermes-gateway`。
   launchd.agents = lib.optionalAttrs pkgs.stdenv.isDarwin {
     hermes-gateway = {
       enable = true;
@@ -352,7 +357,14 @@ in
         ProgramArguments = [
           "/bin/sh"
           "-c"
-          ''/bin/wait4path "${config.home.homeDirectory}/.local/bin/hermes" && exec "${config.home.homeDirectory}/.local/bin/hermes" gateway''
+          ''
+            MARKER="${config.home.homeDirectory}/.hermes/.gateway-primary"
+            if [ ! -f "$MARKER" ]; then
+              echo "hermes-gateway: $MARKER not found on this host — skipping (opt-in via 'touch $MARKER')" >&2
+              exit 0
+            fi
+            /bin/wait4path "${config.home.homeDirectory}/.local/bin/hermes" && exec "${config.home.homeDirectory}/.local/bin/hermes" gateway
+          ''
         ];
         EnvironmentVariables = {
           PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${config.home.homeDirectory}/.local/bin";

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -303,7 +303,7 @@ in
         exit 0
       fi
 
-      mkdir -p "$HERMES_DIR/plugins"
+      mkdir -p "$HERMES_DIR/plugins" "$HERMES_DIR/logs"
 
       # config.yaml — symlink (上書き不可ファイルは事前削除)
       if [ -f "$HERMES_DIR/config.yaml" ] && [ ! -L "$HERMES_DIR/config.yaml" ]; then
@@ -340,5 +340,35 @@ in
   # macOS: launchd agent, Linux: systemd user service
   services.ollama = {
     enable = true;
+  };
+
+  # hermes gateway をログイン時に自動起動 (macOS 限定)
+  # Docker Desktop が未起動でも KeepAlive + ThrottleInterval で復旧するまで再試行
+  launchd.agents = lib.optionalAttrs pkgs.stdenv.isDarwin {
+    hermes-gateway = {
+      enable = true;
+      config = {
+        Label = "com.playpark.hermes-gateway";
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          ''/bin/wait4path "${config.home.homeDirectory}/.local/bin/hermes" && exec "${config.home.homeDirectory}/.local/bin/hermes" gateway''
+        ];
+        EnvironmentVariables = {
+          PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${config.home.homeDirectory}/.local/bin";
+          HOME = config.home.homeDirectory;
+        };
+        WorkingDirectory = "${config.home.homeDirectory}/.hermes";
+        RunAtLoad = true;
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        StandardOutPath = "${config.home.homeDirectory}/.hermes/logs/gateway.out.log";
+        StandardErrorPath = "${config.home.homeDirectory}/.hermes/logs/gateway.err.log";
+        ThrottleInterval = 30;
+      };
+    };
   };
 }


### PR DESCRIPTION
## Summary

- ログイン時に `com.playpark.hermes-gateway` (launchd agent) が `hermes gateway` を background 起動
- `KeepAlive` (Crashed + 非0 exit) + `ThrottleInterval=30` で Docker Desktop の起動遅延 / 一時的な network 断にも自動復旧
- logs は `~/.hermes/logs/gateway.{out,err}.log` に分離

## 構成

- `home-manager/home/default.nix` に `launchd.agents.hermes-gateway` を追加
  - `lib.optionalAttrs pkgs.stdenv.isDarwin` で囲み Linux 構成には影響なし
  - PATH に `/opt/homebrew/bin` を含め docker CLI を解決可能に
  - `/bin/wait4path` で `~/.local/bin/hermes` 出現を待ってから exec
- `activation.setupHermes` で `~/.hermes/logs/` を mkdir
- `hermes/README.md` の「起動」セクションを agent 仕様に更新 (foreground debug 手順も併記)

## Test plan

- [x] `nix flake check` — formatter pass
- [x] `nix run .#update` — home-manager activation 成功
- [x] `~/Library/LaunchAgents/com.playpark.hermes-gateway.plist` 配置確認
- [x] `launchctl list | grep hermes` で PID 確認 (74082 で稼働確認済み)
- [x] `~/.hermes/logs/gateway.{out,err}.log` への書き込み確認
- [ ] (運用確認) macOS 再起動後にログイン時自動起動することを確認
- [ ] (運用確認) Docker Desktop 未起動状態からの自動復旧を確認

## Notes

darwin/ は変更していないため `nix run .#update` の nix-darwin step (sudo 必要) は skip OK。