### PR TITLE
feat(hermes): docker image に Claude Code (Node.js v24) を同梱

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,11 @@
             inherit pkgs;
             mode = "container";
           };
+          # @anthropic-ai/claude-code derivation
+          # 案A: pkgs.claude-code (nixpkgs に存在する場合、推奨)
+          # 案B: pkgs.buildNpmPackage fallback (lib/hermes-claude-code-pkg.nix 内で定義)
+          # 案C (禁止): extraCommands 内 npm install -g は hermetic ではないため不可
+          claudeCodePkg = import ./lib/hermes-claude-code-pkg.nix { inherit pkgs; };
         in
         nixpkgs.lib.optionalAttrs (nixpkgs.lib.hasSuffix "-linux" system) {
           hermes-image = pkgs.dockerTools.buildLayeredImage {
@@ -139,6 +144,7 @@
             tag = "latest";
             contents =
               cliPackages
+              ++ [ claudeCodePkg ]
               ++ (with pkgs; [
                 bashInteractive
                 cacert
@@ -153,6 +159,13 @@
                 less
                 shadow
               ]);
+            # claude が起動時に ~/.claude/ への書き込みを試みる場合に備え、
+            # /root を作成して writable にする。
+            # fakeNss は /etc/passwd の root entry のみ作るため /root 自体は別途保証が必要。
+            extraCommands = ''
+              mkdir -p root
+              chmod 700 root
+            '';
             config = {
               Cmd = [ "${pkgs.bashInteractive}/bin/bash" ];
               WorkingDir = "/workspace";
@@ -160,6 +173,7 @@
                 "PATH=/bin:/usr/bin"
                 "LANG=C.UTF-8"
                 "LC_ALL=C.UTF-8"
+                "HOME=/root"
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 # gws は default で keyring (macOS Keychain) を使うため container では復号不可。
                 # gws auth export で生成した token.json を file backend 経由で読む。

--- a/hermes/.env.template
+++ b/hermes/.env.template
@@ -17,3 +17,10 @@ GATEWAY_ALLOW_ALL_USERS=false
 # Git identity (forwarded into Docker container)
 GIT_AUTHOR_NAME=yuji naramoto
 GIT_AUTHOR_EMAIL=yuji.naramoto@playpark.work
+
+# Claude Code (container subscription token, separate from host ~/.claude/)
+# 発行方法: host 側で `claude setup-token` を実行し OAuth flow で取得した長寿命 token を投入。
+# host の ~/.claude/.credentials.json とは別の container 専用 token を発行すること。
+# (同一 token を host/container で共有すると rotation 競合・rate limit のリスクがある)
+# 既存 ~/.hermes/.env を持つ場合は以下を追記: echo 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-...' >> ~/.hermes/.env
+CLAUDE_CODE_OAUTH_TOKEN=

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -48,8 +48,15 @@ nix run .#update
 | `SLACK_APP_TOKEN` (xapp-) | Slack App → Basic Information → App-Level Tokens (`connections:write`) |
 | `SLACK_ALLOWED_USERS` | Slack profile → Copy member ID |
 | `SLACK_HOME_CHANNEL` | 専用 channel ID |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude setup-token` で発行 (下記参照) |
 
 `chmod 600 ~/.hermes/.env` は activation で実施済み。
+
+> **既存 `~/.hermes/.env` を持つユーザ向け追記手順** (activation は既存 `.env` を上書きしない):
+>
+> ```bash
+> echo 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-...' >> ~/.hermes/.env
+> ```
 
 ### model 切替
 
@@ -143,6 +150,66 @@ hermes built-in approvals が見落とす deny を補強する。
 `pre_tool_call` フックで `tool_name` / `args.command|path|file_path|paths` を走査し、
 マッチしたら `{"action": "block", ...}` を返す。
 
+## Claude Code in container (subscription)
+
+### 概要
+
+`hermes-tools:latest` image に Node.js v24 + `@anthropic-ai/claude-code` が同梱されている (#61)。
+`CLAUDE_CODE_OAUTH_TOKEN` env を container に forward することで、**Claude Pro/Max subscription 枠**
+内で `claude --bg` + `claude agents` 経路を使い、ghq 配下 repo の project skill を実行できる。
+
+> **subscription 経路について**: `claude --bg` + `claude agents` は 2026-06-15 以降も subscription 内。
+> API billing になるのは Agent SDK (TypeScript/Python library) と `claude -p` のみ。
+
+### container 専用 OAuth token の発行 (初回のみ)
+
+host の `~/.claude/.credentials.json` を bind mount する方法は rotation 競合リスクがあるため非推奨。
+`claude setup-token` で **container 専用の長寿命 OAuth token** を別途発行すること。
+
+```bash
+# host 上で実行
+claude setup-token
+# → ブラウザが開き OAuth flow → token (sk-ant-oat-...) が表示される
+# → ~/.hermes/.env の CLAUDE_CODE_OAUTH_TOKEN= に貼り付け
+```
+
+### image の build と動作確認
+
+```bash
+# image build (darwin host では nix.linux-builder 経由で aarch64-linux image を build)
+nix run .#hermes-image-load
+
+# 動作確認
+docker run --rm hermes-tools:latest claude --version
+docker run --rm hermes-tools:latest node --version  # v24.x が返ること
+
+# token 認証確認
+docker run --rm \
+  -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+  hermes-tools:latest \
+  claude --version
+```
+
+### smoke test の実行
+
+```bash
+# docker/build が必要なためローカル手動実行のみ (CI 対象外)
+bash tests/hermes-image-smoke.sh            # すべてのテスト
+bash tests/hermes-image-smoke.sh --skip-build   # nix build をスキップ
+bash tests/hermes-image-smoke.sh --skip-docker  # docker run をスキップ
+```
+
+### Troubleshooting
+
+| 症状 | 原因 | 対策 |
+|------|------|------|
+| `claude: not authenticated` | `CLAUDE_CODE_OAUTH_TOKEN` が空または未設定 | `.env` に token を投入し hermes を再起動 |
+| `nix build: 'aarch64-linux' required` | darwin host で linux-builder 未設定 | [README #55 の手順](../README.md) を参照 |
+| `claude --version` が失敗 | image が古い (`claude-code` 未同梱) | `nix run .#hermes-image-load` で再 build |
+
+> **follow-up**: Phase 3 (workspace/worktree 構成)・Phase 4 (`claude --bg` container 跨ぎ検証)・
+> Phase 5 (hermes plugin 化) は別 issue に切り出し予定。
+
 ## Rollback
 
 ```bash
@@ -159,3 +226,5 @@ rm -rf ~/.hermes/{config.yaml,plugins/path_guard}
 - [Security guide](https://hermes-agent.nousresearch.com/docs/user-guide/security)
 - 前段 issue: [#55](https://github.com/it-all-playpark/dotfiles/issues/55) — hermes-tools docker image
 - 親 issue: [#57](https://github.com/it-all-playpark/dotfiles/issues/57)
+- [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference)
+- [Claude Code authentication](https://code.claude.com/docs/en/authentication)

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -31,6 +31,7 @@ terminal:
     - "GIT_AUTHOR_NAME"
     - "GIT_AUTHOR_EMAIL"
     - "GH_TOKEN"
+    - "CLAUDE_CODE_OAUTH_TOKEN"
   docker_volumes:
     - "/Users/naramotoyuuji/ghq:/workspace/repos:ro"
     - "/Users/naramotoyuuji/Documents/hermes-out:/workspace/out:rw"

--- a/lib/cli-packages.nix
+++ b/lib/cli-packages.nix
@@ -1,7 +1,7 @@
 # CLI tool 一覧の単一ソース化
 #
 # mode = "host"      → 開発マシン用フルセット (host common + host-only)
-# mode = "container" → hermes-agent 用 Docker image 向けの最小セット (host common のみ)
+# mode = "container" → hermes-agent 用 Docker image 向けのセット (common + containerOnly)
 #
 # 使用例:
 #   home-manager/home/default.nix:
@@ -46,6 +46,7 @@ let
   ];
 
   # host のみ (開発マシン専用、container には不要)
+  # NOTE: Node.js は host では mise ("node = lts") で管理。PATH 衝突を避けるためここには入れない。
   hostOnly = with pkgs; [
     act
     fastfetch
@@ -61,10 +62,17 @@ let
     rclone
     tbls
   ];
+
+  # container のみ (hermes-tools Docker image 向け)
+  # Node.js v24 (Active LTS) を同梱し、Claude Code CLI を動かすための runtime を提供する。
+  # host では mise で "node = lts" 管理しているため containerOnly に分離して PATH 衝突を防ぐ。
+  containerOnly = with pkgs; [
+    nodejs_24
+  ];
 in
 if mode == "host" then
   common ++ hostOnly
 else if mode == "container" then
-  common
+  common ++ containerOnly
 else
   throw "cli-packages.nix: unknown mode '${mode}', expected 'host' or 'container'"

--- a/lib/hermes-claude-code-pkg.nix
+++ b/lib/hermes-claude-code-pkg.nix
@@ -1,0 +1,30 @@
+# lib/hermes-claude-code-pkg.nix
+#
+# @anthropic-ai/claude-code の Nix derivation を返す。
+#
+# 優先順 (案A → 案B):
+#   案A: pkgs.claude-code が nixpkgs に存在する場合はそれを使用 (再現性最高、layer 最小)
+#   案B: 存在しない場合は pkgs.buildNpmPackage で hermetic build を構築
+#   案C (禁止): extraCommands 内 npm install -g は image の再現性を壊すため使用しない
+#
+# 使用例 (flake.nix の dockerTools.buildLayeredImage.contents 内):
+#   (import ./lib/hermes-claude-code-pkg.nix { inherit pkgs; })
+#
+# 案A の場合、`claude` バイナリは derivation の ${out}/bin/claude に置かれ、
+# dockerTools.buildLayeredImage が /bin/claude にリンクする。
+# PATH への追加は不要 (buildLayeredImage が自動で /bin を構成する)。
+{
+  pkgs,
+}:
+
+if pkgs ? claude-code then
+  # 案A: nixpkgs に claude-code derivation が存在する (推奨)
+  # nix search nixpkgs claude-code で確認済み (2026-05-27 時点: 2.1.148)
+  pkgs.claude-code
+else
+  throw ''
+    hermes-claude-code-pkg: pkgs.claude-code が nixpkgs に見つかりません。
+    nixpkgs channel を更新するか、lib/hermes-claude-code-pkg.nix を
+    buildNpmPackage ベースの 案B 実装に切り替えてください。
+    (案C: extraCommands 内 npm install -g は禁止)
+  ''

--- a/tests/cli-packages.test.sh
+++ b/tests/cli-packages.test.sh
@@ -25,12 +25,24 @@ fail() {
 
 # ---------------------------------------------------------------------------
 # Helper: evaluate cli-packages.nix and return JSON list of package names
+#
+# flake の pinned nixpkgs を `builtins.getFlake` 経由で取得することで、
+# host の nix-channel 設定 (<nixpkgs>) に依存せず flake.lock と同じ nixpkgs で
+# 評価する。これにより CI / 開発環境で評価結果が一致する。
 # ---------------------------------------------------------------------------
 eval_pkg_names() {
   local mode="$1"
-  nix eval --json --impure --expr \
-    "map (p: p.pname or p.name) (import ${REPO_ROOT}/lib/cli-packages.nix { pkgs = (import <nixpkgs> {}); mode = \"${mode}\"; })" \
-    2>/dev/null
+  local system
+  system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+  nix eval --json --impure --expr "
+    let
+      flake = builtins.getFlake \"${REPO_ROOT}\";
+      pkgs = flake.inputs.nixpkgs.legacyPackages.${system};
+    in
+      map (p: p.pname or p.name) (
+        import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; mode = \"${mode}\"; }
+      )
+  " 2>/dev/null
 }
 
 echo "=== cli-packages.nix unit tests ==="

--- a/tests/cli-packages.test.sh
+++ b/tests/cli-packages.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/cli-packages.test.sh
+# Unit test for lib/cli-packages.nix via nix eval.
+# Run from the repo root: bash tests/cli-packages.test.sh
+# Requires: nix (with flakes), jq
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "        $2"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("$1: $2")
+}
+
+# ---------------------------------------------------------------------------
+# Helper: evaluate cli-packages.nix and return JSON list of package names
+# ---------------------------------------------------------------------------
+eval_pkg_names() {
+  local mode="$1"
+  nix eval --json --impure --expr \
+    "map (p: p.pname or p.name) (import ${REPO_ROOT}/lib/cli-packages.nix { pkgs = (import <nixpkgs> {}); mode = \"${mode}\"; })" \
+    2>/dev/null
+}
+
+echo "=== cli-packages.nix unit tests ==="
+
+# ---------------------------------------------------------------------------
+# AC1: container mode must include nodejs_24
+# ---------------------------------------------------------------------------
+echo "- containerMode_includes_nodejs_24"
+container_pkgs="$(eval_pkg_names "container")"
+if echo "${container_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length > 0' >/dev/null 2>&1; then
+  pass "containerMode_includes_nodejs_24"
+else
+  fail "containerMode_includes_nodejs_24" \
+    "Expected nodejs* in container mode packages, got: ${container_pkgs}"
+fi
+
+# ---------------------------------------------------------------------------
+# AC1 supplement: host mode must NOT include nodejs (PATH collision guard)
+# ---------------------------------------------------------------------------
+echo "- hostMode_unchanged_no_nodejs_in_cli_packages"
+host_pkgs="$(eval_pkg_names "host")"
+if echo "${host_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length == 0' >/dev/null 2>&1; then
+  pass "hostMode_unchanged_no_nodejs_in_cli_packages"
+else
+  fail "hostMode_unchanged_no_nodejs_in_cli_packages" \
+    "nodejs must NOT appear in host mode (managed by mise). Got: ${host_pkgs}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+  exit 1
+fi

--- a/tests/hermes-image-smoke.sh
+++ b/tests/hermes-image-smoke.sh
@@ -78,8 +78,16 @@ echo "- docker_run_claude_version_succeeds"
 if [ "${SKIP_DOCKER}" = "true" ]; then
   skip "docker_run_claude_version_succeeds" "--skip-docker"
 else
-  claude_out="$(docker run --rm hermes-tools:latest claude --version 2>&1)"
-  claude_exit=$?
+  # NOTE: `set -e` 下では `var="$(cmd)"` の assignment 後の `$?` は assignment 自体の
+  # 終了コード (常に 0) を返してしまい、かつ cmd 失敗時は assignment 段階で
+  # script 全体が exit してしまう。これを避けるため `|| true` で exit を抑止しつつ、
+  # 出力末尾に exit code を埋め込んで一度の docker 実行で値と exit を取得する。
+  claude_run_result="$(
+    docker run --rm hermes-tools:latest claude --version 2>&1
+    printf '\n__EXIT__=%d' "$?" || true
+  )"
+  claude_exit="${claude_run_result##*__EXIT__=}"
+  claude_out="${claude_run_result%$'\n'__EXIT__=*}"
   if [ "${claude_exit}" -eq 0 ] && echo "${claude_out}" | grep -qE '[0-9]+\.[0-9]+'; then
     pass "docker_run_claude_version_succeeds"
   else

--- a/tests/hermes-image-smoke.sh
+++ b/tests/hermes-image-smoke.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# tests/hermes-image-smoke.sh
+# Smoke / integration tests for hermes-tools:latest docker image and config files.
+#
+# Usage:
+#   bash tests/hermes-image-smoke.sh            # Run all tests
+#   bash tests/hermes-image-smoke.sh --skip-build  # Skip nix build check
+#   bash tests/hermes-image-smoke.sh --skip-docker # Skip docker run tests
+#
+# Requires: nix (with flakes), docker (optional with --skip-docker), jq, grep
+#
+# NOTE: This test file is intentionally NOT added to `nix flake check` because
+# it requires a running Docker daemon and (on macOS) a linux-builder.
+# Run locally after `nix run .#hermes-image-load`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKIP_BUILD=false
+SKIP_DOCKER=false
+PASS=0
+FAIL=0
+ERRORS=()
+
+# Parse flags
+for arg in "$@"; do
+  case "${arg}" in
+  --skip-build) SKIP_BUILD=true ;;
+  --skip-docker) SKIP_DOCKER=true ;;
+  *)
+    echo "Unknown flag: ${arg}" >&2
+    exit 1
+    ;;
+  esac
+done
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "        $2"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("$1: $2")
+}
+
+skip() {
+  echo "  SKIP: $1 (${2})"
+}
+
+echo "=== hermes-image smoke tests ==="
+echo "  REPO_ROOT: ${REPO_ROOT}"
+echo "  SKIP_BUILD: ${SKIP_BUILD}, SKIP_DOCKER: ${SKIP_DOCKER}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC1 supplement: nix build hermes-image succeeds (integration)
+# ---------------------------------------------------------------------------
+echo "- nix_build_hermes_image_succeeds"
+if [ "${SKIP_BUILD}" = "true" ]; then
+  skip "nix_build_hermes_image_succeeds" "--skip-build"
+else
+  if nix build "${REPO_ROOT}#packages.aarch64-linux.hermes-image" \
+    --no-link 2>&1 | grep -v "^$" | tail -5; then
+    pass "nix_build_hermes_image_succeeds"
+  else
+    fail "nix_build_hermes_image_succeeds" \
+      "nix build .#packages.aarch64-linux.hermes-image failed"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# AC2: claude CLI runs inside container
+# ---------------------------------------------------------------------------
+echo "- docker_run_claude_version_succeeds"
+if [ "${SKIP_DOCKER}" = "true" ]; then
+  skip "docker_run_claude_version_succeeds" "--skip-docker"
+else
+  claude_out="$(docker run --rm hermes-tools:latest claude --version 2>&1)"
+  claude_exit=$?
+  if [ "${claude_exit}" -eq 0 ] && echo "${claude_out}" | grep -qE '[0-9]+\.[0-9]+'; then
+    pass "docker_run_claude_version_succeeds"
+  else
+    fail "docker_run_claude_version_succeeds" \
+      "claude --version exited ${claude_exit} or no version string found. Output: ${claude_out}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# AC2 supplement: node version is v24.x
+# ---------------------------------------------------------------------------
+echo "- docker_run_node_version_is_v24"
+if [ "${SKIP_DOCKER}" = "true" ]; then
+  skip "docker_run_node_version_is_v24" "--skip-docker"
+else
+  node_out="$(docker run --rm hermes-tools:latest node --version 2>&1)"
+  if echo "${node_out}" | grep -qE '^v24\.'; then
+    pass "docker_run_node_version_is_v24"
+  else
+    fail "docker_run_node_version_is_v24" \
+      "Expected v24.x from node --version, got: ${node_out}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# AC3: config.yaml forwards CLAUDE_CODE_OAUTH_TOKEN
+# ---------------------------------------------------------------------------
+echo "- config_yaml_forwards_oauth_token"
+if grep -qF "CLAUDE_CODE_OAUTH_TOKEN" "${REPO_ROOT}/hermes/config.yaml"; then
+  pass "config_yaml_forwards_oauth_token"
+else
+  fail "config_yaml_forwards_oauth_token" \
+    "CLAUDE_CODE_OAUTH_TOKEN not found in hermes/config.yaml docker_forward_env"
+fi
+
+# ---------------------------------------------------------------------------
+# AC3 supplement: .env.template has placeholder
+# ---------------------------------------------------------------------------
+echo "- env_template_has_claude_oauth_placeholder"
+if grep -qE '^CLAUDE_CODE_OAUTH_TOKEN=' "${REPO_ROOT}/hermes/.env.template"; then
+  pass "env_template_has_claude_oauth_placeholder"
+else
+  fail "env_template_has_claude_oauth_placeholder" \
+    "CLAUDE_CODE_OAUTH_TOKEN= not found in hermes/.env.template"
+fi
+
+# ---------------------------------------------------------------------------
+# AC4: README documents claude setup-token procedure
+# ---------------------------------------------------------------------------
+echo "- readme_documents_claude_setup_token"
+if grep -qF "claude setup-token" "${REPO_ROOT}/hermes/README.md"; then
+  pass "readme_documents_claude_setup_token"
+else
+  fail "readme_documents_claude_setup_token" \
+    "'claude setup-token' not found in hermes/README.md"
+fi
+
+# ---------------------------------------------------------------------------
+# AC5: treefmt check and shellcheck pass
+# ---------------------------------------------------------------------------
+echo "- formatters_and_shellcheck_pass"
+fmt_ok=true
+sc_ok=true
+
+if command -v treefmt >/dev/null 2>&1; then
+  if ! treefmt --fail-on-change --no-cache --tree-root "${REPO_ROOT}" 2>&1 | tail -3; then
+    fmt_ok=false
+  fi
+else
+  echo "    (treefmt not in PATH, skipping formatter check — run 'nix develop' first)"
+fi
+
+if command -v shellcheck >/dev/null 2>&1; then
+  shell_targets=()
+  # shellcheck disable=SC2207
+  if compgen -G "${REPO_ROOT}/tests/*.sh" >/dev/null 2>&1; then
+    shell_targets+=("${REPO_ROOT}/tests/"*.sh)
+  fi
+  if compgen -G "${REPO_ROOT}/hermes/scripts/*.sh" >/dev/null 2>&1; then
+    shell_targets+=("${REPO_ROOT}/hermes/scripts/"*.sh)
+  fi
+  if [ "${#shell_targets[@]}" -gt 0 ]; then
+    if ! shellcheck "${shell_targets[@]}" 2>&1; then
+      sc_ok=false
+    fi
+  fi
+else
+  echo "    (shellcheck not in PATH, skipping — run 'nix develop' first)"
+fi
+
+if [ "${fmt_ok}" = "true" ] && [ "${sc_ok}" = "true" ]; then
+  pass "formatters_and_shellcheck_pass"
+else
+  fail "formatters_and_shellcheck_pass" \
+    "fmt_ok=${fmt_ok}, sc_ok=${sc_ok}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Closes #61

hermes-tools:latest docker image に **Node.js v24 + `@anthropic-ai/claude-code`** を同梱し、
container 内で `CLAUDE_CODE_OAUTH_TOKEN` (Claude Pro/Max subscription 枠の OAuth token) を受け取れる状態にする。

本 PR は **Phase 1 (image 同梱) + Phase 2 (OAuth token forward 設定)** のみを対象とする。
Phase 3 (workspace/worktree 構成)・Phase 4 (`claude --bg` container 跨ぎ PoC)・Phase 5 (hermes plugin 化)
は未確定事項の実機検証が必要なため後続 issue に分割。

## 動機

- #55 で `hermes-tools:latest` image、#57 で hermes-agent 設定が整った
- 現状の image には Node.js / Claude Code が同梱されていないため `claude` コマンドが存在しない
- ghq 配下 repo に対して `claude --bg "/sales sync ..."` のような project skill を起動できるようにする
- Claude Pro/Max subscription 枠で動作させる (`--bg` + `claude agents` 経路は subscription 内)

## 変更内容

| ファイル | 変更種別 | 説明 |
|---------|----------|------|
| `lib/cli-packages.nix` | 修正 | `containerOnly = [ nodejs_24 ]` 配列を新設。container mode で `common ++ containerOnly` を返すよう変更。host mode は変更なし (mise で node = lts 管理) |
| `lib/hermes-claude-code-pkg.nix` | 新規 | `pkgs.claude-code` (nixpkgs 案A) を返す derivation。不在時は fail-fast `throw`。`npm install -g` (案C) は hermetic でないため禁止 |
| `flake.nix` | 修正 | `hermes-image.contents` に `claudeCodePkg` を追加。`extraCommands` で `/root` を writable に保証。`HOME=/root` を `Env` に明示 |
| `hermes/.env.template` | 修正 | `CLAUDE_CODE_OAUTH_TOKEN=` placeholder と発行手順コメントを追記 |
| `hermes/config.yaml` | 修正 | `terminal.docker_forward_env` に `CLAUDE_CODE_OAUTH_TOKEN` を追加 |
| `hermes/README.md` | 修正 | tokens 表に `CLAUDE_CODE_OAUTH_TOKEN` 行を追加。「Claude Code in container」セクションを新設 (token 発行・image build・smoke test・troubleshooting) |
| `tests/cli-packages.test.sh` | 新規 | `nix eval` で container/host mode の nodejs 有無を assert する unit test |
| `tests/hermes-image-smoke.sh` | 新規 | docker run + config grep 系 smoke test。`--skip-build` / `--skip-docker` フラグで CI/ローカルを分離 |

## アーキテクチャ上の判断

- **案A (`pkgs.claude-code`) を採用**: nixpkgs に `claude-code 2.1.148` が存在することを `nix search` で確認済み。再現性が最高で image layer が最小。
- **`NPM_CONFIG_PREFIX` は不要**: `pkgs.claude-code` は `buildLayeredImage` が `/bin/claude` を自動配置するため PATH 追加不要。
- **container 専用 OAuth token を必須化**: host `~/.claude/.credentials.json` の bind mount は rotation 競合リスク・`claude logout` 誤打によるホストセッション消失リスクがあるため非推奨。`claude setup-token` で別途発行。
- **`/root` の writable 保証**: `dockerTools.fakeNss` は `/etc/passwd` の root entry のみ作成。`/root` 自体は `extraCommands` で明示的に `mkdir -p + chmod 700` する。

## テスト計画

TDD (Red → Green) で実装。

| テスト | 結果 |
|--------|------|
| `containerMode_includes_nodejs_24` (nix eval) | PASS |
| `hostMode_unchanged_no_nodejs_in_cli_packages` (nix eval) | PASS |
| `config_yaml_forwards_oauth_token` (grep) | PASS |
| `env_template_has_claude_oauth_placeholder` (grep) | PASS |
| `readme_documents_claude_setup_token` (grep) | PASS |
| `nix flake check` (treefmt formatting) | PASS |

docker/build が必要な integration test (`docker_run_claude_version_succeeds` 等) は
`nix run .#hermes-image-load` 後にローカル手動実行 (`bash tests/hermes-image-smoke.sh`)。

## 動作確認手順 (レビュアー向け)

```bash
# image build (darwin host では nix.linux-builder が必要)
nix run .#hermes-image-load

# 動作確認
docker run --rm hermes-tools:latest claude --version   # バージョン文字列が返ること
docker run --rm hermes-tools:latest node --version     # v24.x が返ること
```

## スコープ外 (後続 issue)

- Phase 3: `claude-worktrees` rw mount + wrapper script (`hermes/scripts/claude-in-repo.sh`)
- Phase 4: `claude --bg` session の container 跨ぎ生存性 PoC
- Phase 5: hermes plugin 化 (`hermes/plugins/claude_runner/`)