### PR TITLE
feat(hermes): container 専用 claude settings を分離し host と挙動統一

### DIFF
--- a/claude-code/container.settings.json
+++ b/claude-code/container.settings.json
@@ -1,0 +1,371 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Bash",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskOutput",
+      "TaskStop",
+      "TaskUpdate",
+      "Skill",
+      "WebSearch",
+      "mcp__plugin_telegram_telegram__reply",
+      "mcp__plugin_telegram_telegram__react",
+      "mcp__plugin_telegram_telegram__edit_message",
+      "mcp__plugin_telegram_telegram__download_attachment"
+    ],
+    "deny": [
+      "Bash(gh repo delete:*)",
+      "Bash(gh repo rename:*)",
+      "Bash(gh repo transfer:*)",
+      "Bash(gh repo edit:*)",
+      "Bash(gh repo fork:*)",
+      "Bash(gh release delete:*)",
+      "Bash(gh secret set:*)",
+      "Bash(gh secret remove:*)",
+      "Bash(gh auth token:*)",
+      "Bash(gh api --method DELETE:*)",
+      "Bash(gh api --method POST:*)",
+      "Bash(gh api --method PUT:*)",
+      "Bash(gh api --method PATCH:*)",
+      "Bash(gh api -X DELETE:*)",
+      "Bash(gh api -X POST:*)",
+      "Bash(gh api -X PUT:*)",
+      "Bash(gh api -X PATCH:*)",
+      "Bash(gh api graphql:*)",
+      "Bash(git push --mirror:*)",
+      "Bash(git push --all:*)",
+      "Bash(git push --tags:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push origin HEAD:refs/heads/dev)",
+      "Bash(git push origin HEAD:refs/heads/develop)",
+      "Bash(git push origin HEAD:refs/heads/development)",
+      "Bash(git push origin HEAD:refs/heads/main)",
+      "Bash(git push origin HEAD:refs/heads/master)",
+      "Bash(git push --set-upstream origin dev)",
+      "Bash(git push --set-upstream origin develop)",
+      "Bash(git push --set-upstream origin development)",
+      "Bash(git push --set-upstream origin main)",
+      "Bash(git push --set-upstream origin master)",
+      "Bash(git push --force-with-lease origin HEAD:refs/heads/dev)",
+      "Bash(git push --force-with-lease origin HEAD:refs/heads/develop)",
+      "Bash(git push --force-with-lease origin HEAD:refs/heads/development)",
+      "Bash(git push --force-with-lease origin HEAD:refs/heads/main)",
+      "Bash(git push --force-with-lease origin HEAD:refs/heads/master)",
+      "Bash(git push origin dev:dev)",
+      "Bash(git push origin develop:develop)",
+      "Bash(git push origin development:development)",
+      "Bash(git push origin main:main)",
+      "Bash(git push origin master:master)",
+      "Bash(git push origin :*)",
+      "Bash(git push *:main)",
+      "Bash(git push *:master)",
+      "Bash(git push *:dev)",
+      "Bash(git push *:develop)",
+      "Bash(git push *:development)",
+      "Bash(git push *:refs/heads/main)",
+      "Bash(git push *:refs/heads/master)",
+      "Bash(git push *:refs/heads/dev)",
+      "Bash(git push *:refs/heads/develop)",
+      "Bash(git push *:refs/heads/development)",
+      "Bash(git push origin --delete dev)",
+      "Bash(git push origin --delete develop)",
+      "Bash(git push origin --delete development)",
+      "Bash(git push origin --delete main)",
+      "Bash(git push origin --delete master)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -f:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git clean -fx:*)",
+      "Bash(git clean -xf:*)",
+      "Bash(git checkout -- .:*)",
+      "Bash(git restore .:*)",
+      "Bash(git branch -D:*)",
+      "Bash(sudo:*)",
+      "Bash(rm -rf:*)",
+      "Bash(rm -fr:*)",
+      "Bash(rm -r -f:*)",
+      "Bash(rm -f -r:*)",
+      "Bash(rm -r /*)",
+      "Bash(rm -r /:*)",
+      "Bash(/bin/rm -rf:*)",
+      "Bash(/bin/rm -fr:*)",
+      "Bash(/bin/rm -r -f:*)",
+      "Bash(/bin/rm -f -r:*)",
+      "Bash(/bin/rm -r:*)",
+      "Bash(find / -delete:*)",
+      "Bash(find / -exec rm -rf {} \\;:*)",
+      "Bash(chmod -R:*)",
+      "Bash(chown -R:*)",
+      "Bash(chgrp -R:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(ssh:*)",
+      "Bash(nc :*)",
+      "Bash(netcat:*)",
+      "Bash(ncat:*)",
+      "Bash(telnet:*)",
+      "Bash(ftp:*)",
+      "Bash(sftp:*)",
+      "Bash(scp:*)",
+      "Bash(python -c:*)",
+      "Bash(python3 -c:*)",
+      "Bash(node -e:*)",
+      "Bash(node --eval:*)",
+      "Bash(node -p:*)",
+      "Bash(node --print:*)",
+      "Bash(ruby -e:*)",
+      "Bash(perl -e:*)",
+      "Bash(osascript -e:*)",
+      "Bash(osascript:*)",
+      "Bash(bash -c:*)",
+      "Bash(sh -c:*)",
+      "Bash(zsh -c:*)",
+      "Bash(fish -c:*)",
+      "Bash(dash -c:*)",
+      "Bash(eval:*)",
+      "Bash(npx:*)",
+      "Bash(pnpx:*)",
+      "Bash(uvx:*)",
+      "Bash(bunx:*)",
+      "Bash(deno run:*)",
+      "Bash(deno eval:*)",
+      "Bash(brew:*)",
+      "Bash(nix-env -i:*)",
+      "Bash(nix profile install:*)",
+      "Bash(nix-store --delete:*)",
+      "Bash(nix-collect-garbage -d:*)",
+      "Bash(apt-get:*)",
+      "Bash(yum:*)",
+      "Bash(pip install:*)",
+      "Bash(pip3 install:*)",
+      "Bash(pipx install:*)",
+      "Bash(npm publish:*)",
+      "Bash(pnpm publish:*)",
+      "Bash(cargo publish:*)",
+      "Bash(dd:*)",
+      "Bash(mkfs:*)",
+      "Bash(fdisk:*)",
+      "Bash(parted:*)",
+      "Bash(cfdisk:*)",
+      "Bash(sfdisk:*)",
+      "Bash(gdisk:*)",
+      "Bash(sgdisk:*)",
+      "Bash(diskutil:*)",
+      "Bash(format:*)",
+      "Bash(kill -9 -1:*)",
+      "Bash(kill -9 1:*)",
+      "Bash(kill -KILL -1:*)",
+      "Bash(kill -KILL 1:*)",
+      "Bash(kill -TERM -1:*)",
+      "Bash(killall -KILL:*)",
+      "Bash(killall -TERM:*)",
+      "Bash(pkill -KILL:*)",
+      "Bash(pkill -TERM:*)",
+      "Bash(killall -9:*)",
+      "Bash(pkill -9:*)",
+      "Bash(reboot:*)",
+      "Bash(shutdown:*)",
+      "Bash(halt:*)",
+      "Bash(poweroff:*)",
+      "Bash(init 0:*)",
+      "Bash(init 6:*)",
+      "Bash(systemctl reboot:*)",
+      "Bash(systemctl shutdown:*)",
+      "Bash(systemctl poweroff:*)",
+      "Bash(systemctl halt:*)",
+      "Bash(mv /*:*)",
+      "Bash(mv * /:*)",
+      "Bash(cp /*:*)",
+      "Bash(cp * /:*)",
+      "Bash(cp -R * /:*)",
+      "Bash(rsync /*:*)",
+      "Bash(rsync * /:*)",
+      "Bash(tar -xf * -C /:*)",
+      "Bash(tar -xzf * -C /:*)",
+      "Bash(tar -xJf * -C /:*)",
+      "Bash(unzip * -d /:*)",
+      "Bash(ditto /*:*)",
+      "Bash(launchctl unload:*)",
+      "Bash(launchctl load:*)",
+      "Bash(defaults write:*)",
+      "Bash(scutil:*)",
+      "Bash(nvram:*)",
+      "Bash(csrutil:*)",
+      "Bash(spctl:*)",
+      "Bash(networksetup:*)",
+      "Bash(dscl:*)",
+      "Bash(dseditgroup:*)",
+      "Bash(pmset:*)",
+      "Bash(tmutil:*)",
+      "Bash(security find-generic-password:*)",
+      "Bash(security find-internet-password:*)",
+      "Bash(security dump-keychain:*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(./.ssh/**)",
+      "Read(./.gnupg/**)",
+      "Read(./.aws/**)",
+      "Read(./.config/gh/**)"
+    ],
+    "defaultMode": "auto",
+    "disableBypassPermissionsMode": "disable",
+    "additionalDirectories": [
+      "/workspace/repos/github.com/playpark-llc",
+      "/workspace/repos/github.com/it-all-playpark",
+      "/workspace/repos/github.com/Cistree-dev"
+    ]
+  },
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [],
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/pre-compact-dump.sh\"",
+            "timeout": 10,
+            "statusMessage": "session 状態を claudedocs/session-*.md に退避中..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/validate-skill-frontmatter.sh\"",
+            "if": "Write(*/SKILL.md)",
+            "timeout": 5,
+            "statusMessage": "SKILL.md frontmatter バリデーション中..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/allow-feature-push.sh\"",
+            "if": "Bash(git push*)",
+            "timeout": 5,
+            "statusMessage": "push ブランチチェック中..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/pretool-bash-credential-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "prod credential 検知中..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/generate-worktreeinclude.sh\"",
+            "if": "Bash(git worktree add*)",
+            "timeout": 10,
+            "statusMessage": ".worktreeinclude 自動生成チェック中..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/allow-pr-merge.sh\"",
+            "if": "Bash(gh pr merge*)",
+            "timeout": 15,
+            "statusMessage": "PR merge ブランチチェック中..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/posttool-secret-mask.sh\"",
+            "timeout": 5,
+            "statusMessage": "出力内の秘匿情報マスク中..."
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/permission-journal.sh\"",
+            "timeout": 5,
+            "statusMessage": "permission request logging..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/stop-unfinished-guard.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash",
+            "args": [
+              "-c",
+              "rm -f \"/tmp/claude-skill-ctx-${CLAUDE_CODE_SESSION_ID:-unknown}\" 2>/dev/null || true"
+            ],
+            "timeout": 1
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {},
+  "language": "ja",
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": false,
+  "agentPushNotifEnabled": false
+}

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -36,6 +36,16 @@ terminal:
     - "/Users/naramotoyuuji/ghq:/workspace/repos:ro"
     - "/Users/naramotoyuuji/Documents/hermes-out:/workspace/out:rw"
     - "/Users/naramotoyuuji/.config/gws:/root/.config/gws:rw"
+    # host の claude-code/ 配下を /root/.claude/ に部分 mount し
+    # container 内 `claude` の permissions / hooks を host と統一する。
+    # ~/.claude/projects, jobs, memory, skills, plugins, .credentials.json は
+    # container 側 ephemeral に任せるため mount しない (rotation 競合回避)。
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/container.settings.json:/root/.claude/settings.json:ro"
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/hooks:/root/.claude/hooks:ro"
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/CLAUDE.md:/root/.claude/CLAUDE.md:ro"
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/PRINCIPLES.md:/root/.claude/PRINCIPLES.md:ro"
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/RULES.md:/root/.claude/RULES.md:ro"
+    - "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/claude-code/skill-config.json:/root/.claude/skill-config.json:ro"
 
 agent:
   disabled_toolsets: []


### PR DESCRIPTION
## Summary

- container 内 `claude` の permissions / hooks を host と揃えるため、macOS 依存を除いた **container 専用 settings.json** を新設
- `hermes/config.yaml` の `docker_volumes` で `claude-code/` 配下を **部分 mount** (rotation 競合・host runtime 衝突を避ける設計)

## 変更内容

### 新規: `claude-code/container.settings.json`

host `settings.json` から派生。差分:

- **削除した hook** (container で動かない / 害)
  - `Notification` (osascript)
  - `memory-monitor.py` (python3 が image 未同梱)
  - `claude-zombie-kill` / `skill-retrospective journal.sh` (host `~/.claude/skills/` 依存、mount しない)
- **`additionalDirectories`** を container path (`/workspace/repos/github.com/...`) に書き換え
- **`enabledPlugins`** を `{}` に (plugins/ は mount しない)
- **`voiceEnabled` / `agentPushNotifEnabled`** を `false` (container では使えない)
- permissions の `allow` / `deny` は host とフル一致

### 変更: `hermes/config.yaml`

`docker_volumes` に 6 行追加:

```yaml
- container.settings.json → /root/.claude/settings.json:ro
- hooks/ → /root/.claude/hooks:ro
- CLAUDE.md → /root/.claude/CLAUDE.md:ro
- PRINCIPLES.md → /root/.claude/PRINCIPLES.md:ro
- RULES.md → /root/.claude/RULES.md:ro
- skill-config.json → /root/.claude/skill-config.json:ro
```

`projects/` / `jobs/` / `memory/` / `skills/` / `plugins/` / `.credentials.json` は **mount しない** (rotation 競合 / host runtime 衝突回避、README 既存方針と整合)。

## 設計判断

- host の `~/.claude/` 全体 bind は ✗
  - hook が osascript / launchctl / python3 等 macOS 依存
  - `additionalDirectories` の host パスが container path と不一致
  - plugins/ は dotfiles 管理外
  - `.credentials.json` の rotation 競合 (README で明示済み)
- → **container 用 settings を分離 + 部分 mount** で host と挙動統一する案を採用

## Test plan

- [ ] `nix run .#hermes-image-load` で image 再 build
- [ ] `docker run --rm -v <claude-code mounts> hermes-tools:latest claude config get permissions` で permission が反映されているか確認
- [ ] hermes 経由で `claude --bg` を起動し、`git push origin main` 等が deny されることを確認
- [ ] `gh pr merge` の `allow-pr-merge.sh` hook が container 内で発火することを確認
- [ ] 残存 hook (pre-compact-dump, posttool-secret-mask 等) が `$HOME/.claude/logs/` 書き込みエラーを出さないことを確認

## 注意

- main 側に `hermes/config.yaml` の formatting + `onboarding.seen.busy_input_prompt` の dirty change が残っている。本 PR とは別経路で commit / 統合する必要あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)