### PR TITLE
fix(claude-code): API過負荷対策(fallbackModel + タイムアウト延長)

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -1,6 +1,8 @@
 {
+  "fallbackModel": ["claude-opus-4-7", "claude-sonnet-4-6"],
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "API_TIMEOUT_MS": "900000"
   },
   "attribution": {
     "commit": "",


### PR DESCRIPTION
## 背景
opus-4.8で 529 Overloaded が多発し、セッションが止まる事象を調査。ローカルの `~/.claude/projects/**/*.jsonl` を集計したところ、6月に `API error` が急増していた(6/6: 17件, 6/13: 16件, 6/16: 12件, 6/23: 14件 — Anthropicの障害多発期と一致)。

エラー内訳:
| エラー | 件数 | 意味 |
|--------|------|------|
| `Repeated 529 Overloaded errors` | 8 | 内部リトライ10回を使い切って**完全停止** |
| socket closed / idle timeout / connection closed mid | 15 | ストリーミング切断 |

既存設定には `fallbackModel`・`API_TIMEOUT_MS` がどちらも無く、過負荷時の逃げ道が無かった。

## 変更
- `fallbackModel: ["claude-opus-4-7", "claude-sonnet-4-6"]` — 過負荷時にまずOpus 4.7、それも過負荷ならSonnet 4.6へ自動退避し、停止を回避
- `API_TIMEOUT_MS: "900000"`(15分)— stream idle / socket切断系への耐性向上
- `model` は明示せず、現行デフォルト(Opus 4.8 / 1M context)を維持

## 反映
マージ後、メインcheckoutで `git pull` → Claude Code 再起動で有効化。