### PR TITLE
feat(claude-code): stop-devflow-telemetry hook に repo / pr_number パススルーを追加 (skills#309)

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -64,12 +64,16 @@ for f in "${PENDING_DIR}"/*.json; do
   eval_verdict=""
   iterate_status=""
   eval_staleness=""
+  repo=""
+  pr_number=""
 
   if ! parsed=$(jq -e '{
     skill: .skill,
     outcome: .outcome,
     issue: .issue,
     journal_sh: .journal_sh,
+    repo: .repo,
+    pr_number: .pr_number,
     merge_tier: .telemetry.merge_tier,
     gate_policy: .telemetry.gate_policy,
     danger_hits: (.telemetry.danger_hits // []),
@@ -113,6 +117,8 @@ for f in "${PENDING_DIR}"/*.json; do
   eval_verdict=$(echo "$parsed" | jq -r '.eval_verdict // empty')
   iterate_status=$(echo "$parsed" | jq -r '.iterate_status // empty')
   eval_staleness=$(echo "$parsed" | jq -r '.eval_staleness // empty')
+  repo=$(echo "$parsed" | jq -r '.repo // empty')
+  pr_number=$(echo "$parsed" | jq -r '.pr_number // empty')
 
   # --- Resolve journal.sh ---
   journal_sh=""
@@ -149,6 +155,12 @@ for f in "${PENDING_DIR}"/*.json; do
   fi
   if [[ -n $eval_staleness && $eval_staleness != "null" ]]; then
     cmd_args+=(--eval-staleness "$eval_staleness")
+  fi
+  if [[ -n $repo && $repo != "null" ]]; then
+    cmd_args+=(--repo "$repo")
+  fi
+  if [[ -n $pr_number && $pr_number != "null" ]]; then
+    cmd_args+=(--pr-number "$pr_number")
   fi
 
   # --- Execute journal.sh ---

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -248,6 +248,8 @@ STUB_EOF
       outcome: "success",
       issue: 42,
       journal_sh: $js,
+      repo: "acme/skills",
+      pr_number: 123,
       telemetry: {
         merge_tier: "AUTO",
         gate_policy: "llm-autonomous",
@@ -291,6 +293,16 @@ STUB_EOF
       pass "optional_eval_staleness_present"
     else
       fail "optional_eval_staleness_present" "--eval-staleness iterate_fixed not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--repo acme/skills"; then
+      pass "optional_repo_present"
+    else
+      fail "optional_repo_present" "--repo acme/skills not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--pr-number 123"; then
+      pass "optional_pr_number_present"
+    else
+      fail "optional_pr_number_present" "--pr-number 123 not found. got: ${captured}"
     fi
   else
     fail "optional_fields_stub_called" "capture file not created"
@@ -345,6 +357,16 @@ STUB_EOF
       pass "no_eval_staleness_when_absent"
     else
       fail "no_eval_staleness_when_absent" "--eval-staleness should not appear"
+    fi
+    if ! echo "$captured" | grep -q -- "--repo"; then
+      pass "no_repo_when_absent"
+    else
+      fail "no_repo_when_absent" "--repo should not appear"
+    fi
+    if ! echo "$captured" | grep -q -- "--pr-number"; then
+      pass "no_pr_number_when_absent"
+    else
+      fail "no_pr_number_when_absent" "--pr-number should not appear"
     fi
   else
     fail "no_optional_fields_stub_called" "capture file not created"


### PR DESCRIPTION
## 概要

Refs: it-all-playpark/skills#309 / it-all-playpark/skills#311

skills PR #311 で dev-flow/pr-iterate の telemetry handoff JSON にトップレベル `repo`（owner/name）と `pr_number` が追加された。本 hook は既知キーのみ転送するため、このままでは新キーが silently drop され skills#309 の AC「journal エントリに repo/pr_number が記録される」が end-to-end で未達になる。

## 変更

- handoff JSON の `.repo` / `.pr_number` を抽出し、journal.sh の `--repo` / `--pr-number` フラグへ透過
- キー欠落・null 時はフラグを付けない（eval_verdict 等の既存 optional フィールドと同型）
- テスト 4 ケース追加（present 2 + absent 2）— 全 30 pass

## merge 順序

順序制約なし。handoff JSON の `journal_sh` は worktree 内の journal.sh を指すため、新キーを emit する tree と受理する journal.sh は常に同一 tree で自己整合する。hook 側が先に merge されても旧 handoff にはキーが無くフラグは付かない。

## テスト

```
bash claude-code/hooks/stop-devflow-telemetry.test.sh
=== Results: 30 passed, 0 failed ===
```