### PR TITLE
feat(claude-code): op service account で secret を bg claude agent に注入し gh 認証失敗を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ codex/**/*.local.toml
 **/*.credentials.json
 **/oauth-tokens.json
 
+# 1Password op run env overrides (repo-local, contains real vault/item refs)
+.op.env
+**/.op.env
+
 # Nix
 result
 result-*

--- a/README.md
+++ b/README.md
@@ -85,6 +85,74 @@ nix run .#update
 
 flake.nix内のアップデートスクリプトが、home-managerとnix-darwinの両方の設定を切り替えます。
 
+## 1Password Service Account による GH_TOKEN 注入（bg claude agents 向け）
+
+`bg` で spawn される claude agents の sandbox からは credential dir（`~/.config/gh` 等）が deny されるため `gh` 認証が失敗します。これを回避するため、1Password Service Account (SA) を使い env 経由で `GH_TOKEN` を注入します。
+
+### 1. Service Account の作成
+
+1Password で対象 vault への read 権限を持つ Service Account を作成し、SA トークン（`ops_...` 形式）を発行します。
+
+- [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/) のドキュメントに従い作成
+- 対象 vault に対して read 権限を付与
+- 発行された SA トークンを控える（この後 Keychain に格納するので画面には残さない）
+
+### 2. Keychain への格納
+
+SA トークンは macOS Keychain の `claude-op-sa` という service 名で保存します。
+
+```bash
+security add-generic-password -s claude-op-sa -a "$USER" -w
+```
+
+**128 文字切れの罠**: `security add-generic-password -w` はプロンプト（GUI ダイアログや一部の入力経路）経由で値を渡すと 128 文字で切れることがあります。SA トークンは 128 文字を超えることが多いため、必ず以下のいずれかの方法で値を直接渡してください。
+
+```bash
+# pbpaste でクリップボードの値を shell 側から直接渡す（プロンプトへの貼り付けは避ける）
+security add-generic-password -s claude-op-sa -a "$USER" -w "$(pbpaste)"
+```
+
+既に短く切れた値で登録してしまった場合は、一度削除してから入れ直してください。
+
+```bash
+security delete-generic-password -s claude-op-sa
+security add-generic-password -s claude-op-sa -a "$USER" -w "$(pbpaste)"
+```
+
+### 3. env-file の作成
+
+テンプレートをコピーし、`op://` 参照の vault/item 名を実際のものに置き換えます。
+
+```bash
+cp ~/.config/op/claude.env.example ~/.config/op/claude.env
+```
+
+```
+GH_TOKEN=op://<vault>/<item>/token
+```
+
+の `<vault>` と `<item>` を、作成した実 vault/item 名に置換してください。
+
+リポジトリ単位で値を上書きしたい場合は、リポジトリ直下に `.op.env`（`.gitignore` 済み）を配置します。同名キーは repo 側が global (`~/.config/op/claude.env`) を後勝ちで上書きします。
+
+### 4. 疎通確認
+
+SA トークンが有効か確認します（token 平文が端末に表示されるため、確認時のみ実行し、シェル履歴への残留に注意してください）。
+
+```bash
+OP_SERVICE_ACCOUNT_TOKEN=$(security find-generic-password -s claude-op-sa -a "$USER" -w) op vault list
+```
+
+env-file が意図通り解決できるか確認します（同様に平文が出力されるため取り扱い注意）。
+
+```bash
+op run --env-file ~/.config/op/claude.env -- printenv GH_TOKEN
+```
+
+### 仕組み
+
+fish の `claude` 関数が `op run` で `op://` 参照を解決した env を組み立て、`env -u OP_SERVICE_ACCOUNT_TOKEN` で SA トークン自体を除去してから `claude` を起動します。credential dir に対する sandbox の deny 設定はそのまま維持され、env チャネルのみで最小限の secret（`GH_TOKEN` 等）が渡されます。
+
 ## Agent Skills
 
 本リポジトリは [Agent Skills](https://agentskills.io) をサポートしており、複数のAIエージェントツール間でスキルを共有できます。

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -67,6 +67,8 @@ in
       ".myclirc.local.template".source = ./file/.myclirc.local.template;
       ".config/git/config.local.template".source = ./file/git/config.local.template;
       ".config/fish/config.fish.local.template".source = ./file/fish/config.fish.local.template;
+      ".config/fish/functions/claude.fish".source = ./file/fish/functions/claude.fish;
+      ".config/op/claude.env.example".source = ./file/op/claude.env.example;
       ".config/nvim" = {
         source = ./file/nvim;
         recursive = true;

--- a/home-manager/home/file/fish/functions/claude.fish
+++ b/home-manager/home/file/fish/functions/claude.fish
@@ -1,0 +1,29 @@
+function claude --description 'claude wrapped with 1Password service-account GH_TOKEN injection'
+    if not command -v op >/dev/null 2>&1
+        command claude $argv
+        return
+    end
+
+    set -l sa_token (security find-generic-password -s claude-op-sa -a "$USER" -w 2>/dev/null)
+    if test -z "$sa_token"
+        command claude $argv
+        return
+    end
+
+    set -l env_files
+    set -l global_env "$HOME/.config/op/claude.env"
+    if test -f "$global_env"
+        set -a env_files --env-file=$global_env
+    end
+    if test -f ./.op.env
+        set -a env_files --env-file=./.op.env
+    end
+
+    if test (count $env_files) -eq 0
+        command claude $argv
+        return
+    end
+
+    OP_SERVICE_ACCOUNT_TOKEN=$sa_token op run $env_files -- env -u OP_SERVICE_ACCOUNT_TOKEN command claude $argv
+    return $status
+end

--- a/home-manager/home/file/fish/functions/claude.test.fish
+++ b/home-manager/home/file/fish/functions/claude.test.fish
@@ -1,0 +1,185 @@
+#!/usr/bin/env fish
+# Integration tests for the `claude` fish wrapper function (home-manager/home/file/fish/functions/claude.fish)
+#
+# Run with: fish home-manager/home/file/fish/functions/claude.test.fish
+
+set -g func_file (dirname (status --current-filename))/claude.fish
+
+set -g failures 0
+
+function assert_eq --argument-names actual expected message
+    if test "$actual" != "$expected"
+        echo "FAIL: $message (expected: '$expected', actual: '$actual')" >&2
+        set -g failures (math $failures + 1)
+    else
+        echo "PASS: $message"
+    end
+end
+
+function assert_contains --argument-names haystack needle message
+    if string match -q -- "*$needle*" $haystack
+        echo "PASS: $message"
+    else
+        echo "FAIL: $message (needle '$needle' not found)" >&2
+        set -g failures (math $failures + 1)
+    end
+end
+
+function assert_not_contains --argument-names haystack needle message
+    if string match -q -- "*$needle*" $haystack
+        echo "FAIL: $message (needle '$needle' unexpectedly found)" >&2
+        set -g failures (math $failures + 1)
+    else
+        echo "PASS: $message"
+    end
+end
+
+function make_fakebin --argument-names dir
+    mkdir -p $dir
+
+    # fake `op`: parses `--env-file=path` occurrences before `--`, sources
+    # them into the environment, then execs whatever follows `--`.
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'env_files=()' \
+        'rest=()' \
+        'after=0' \
+        'for a in "$@"; do' \
+        '  if [ $after -eq 1 ]; then' \
+        '    rest+=("$a")' \
+        '  elif [ "$a" = "--" ]; then' \
+        '    after=1' \
+        '  elif [[ "$a" == --env-file=* ]]; then' \
+        '    env_files+=("${a#--env-file=}")' \
+        '  fi' \
+        'done' \
+        'for f in "${env_files[@]}"; do' \
+        '  if [ -f "$f" ]; then' \
+        '    while IFS="=" read -r k v; do' \
+        '      [ -z "$k" ] && continue' \
+        '      export "$k=$v"' \
+        '    done < "$f"' \
+        '  fi' \
+        'done' \
+        'exec "${rest[@]}"' \
+        > $dir/op
+    chmod +x $dir/op
+
+    # fake `security`: emits $FAKE_SA_TOKEN (may be empty) regardless of args.
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ -n "$FAKE_SA_TOKEN" ]; then' \
+        '  printf "%s" "$FAKE_SA_TOKEN"' \
+        'fi' \
+        'exit 0' \
+        > $dir/security
+    chmod +x $dir/security
+
+    # fake `claude`: dumps its environment and argv for inspection.
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'env > "$FAKE_CLAUDE_ENV_DUMP"' \
+        'printf "%s\n" "$@" > "$FAKE_CLAUDE_ARGS_DUMP"' \
+        > $dir/claude
+    chmod +x $dir/claude
+end
+
+# ---------------------------------------------------------------------------
+# Test 1: SA token present + env-file layering -> op run injects GH_TOKEN,
+# strips OP_SERVICE_ACCOUNT_TOKEN, and passes argv through to real claude.
+# ---------------------------------------------------------------------------
+function test_with_sa_token
+    set -l tmp (mktemp -d)
+    set -l fakebin $tmp/bin
+    make_fakebin $fakebin
+    mkdir -p $tmp/.config/op
+    echo "GH_TOKEN=fake-gh" >$tmp/.config/op/claude.env
+
+    set -l fake_token (printf 'FAKE-SA-TOKEN-%.0s0' (seq 200))
+
+    set -lx HOME $tmp
+    set -lx PATH $fakebin $PATH
+    set -lx FAKE_SA_TOKEN $fake_token
+    set -lx FAKE_CLAUDE_ENV_DUMP $tmp/env_dump.txt
+    set -lx FAKE_CLAUDE_ARGS_DUMP $tmp/args_dump.txt
+
+    source $func_file
+
+    set -l all_stdout $tmp/all_stdout.txt
+    set -l orig_pwd $PWD
+    cd $tmp
+    claude foo >$all_stdout 2>&1
+    set -l claude_status $status
+
+    assert_eq $claude_status 0 "with-token: wrapper exits 0"
+
+    set -l env_dump ""
+    if test -f $tmp/env_dump.txt
+        set env_dump (cat $tmp/env_dump.txt)
+    end
+    assert_contains "$env_dump" "GH_TOKEN=fake-gh" "with-token: GH_TOKEN injected via op run --env-file"
+    assert_not_contains "$env_dump" "OP_SERVICE_ACCOUNT_TOKEN=" "with-token: OP_SERVICE_ACCOUNT_TOKEN stripped via env -u"
+
+    set -l args_dump ""
+    if test -f $tmp/args_dump.txt
+        set args_dump (cat $tmp/args_dump.txt)
+    end
+    assert_contains "$args_dump" "foo" "with-token: argv passed through to real claude"
+
+    set -l stdout_content (cat $all_stdout)
+    assert_not_contains "$stdout_content" "FAKE-SA-TOKEN" "with-token: SA token value never printed to stdout/stderr"
+
+    cd $orig_pwd
+    rm -rf $tmp
+end
+
+# ---------------------------------------------------------------------------
+# Test 2: no SA token in Keychain -> wrapper falls back to plain
+# `command claude $argv` without ever invoking op run.
+# ---------------------------------------------------------------------------
+function test_without_sa_token
+    set -l tmp (mktemp -d)
+    set -l fakebin $tmp/bin
+    make_fakebin $fakebin
+    mkdir -p $tmp/.config/op
+    echo "GH_TOKEN=fake-gh" >$tmp/.config/op/claude.env
+
+    set -lx HOME $tmp
+    set -lx PATH $fakebin $PATH
+    set -e FAKE_SA_TOKEN
+    set -lx FAKE_CLAUDE_ENV_DUMP $tmp/env_dump.txt
+    set -lx FAKE_CLAUDE_ARGS_DUMP $tmp/args_dump.txt
+
+    source $func_file
+
+    set -l all_stdout $tmp/all_stdout.txt
+    set -l orig_pwd $PWD
+    cd $tmp
+    claude bar >$all_stdout 2>&1
+    set -l claude_status $status
+
+    assert_eq $claude_status 0 "without-token: wrapper exits 0"
+
+    set -l args_dump ""
+    if test -f $tmp/args_dump.txt
+        set args_dump (cat $tmp/args_dump.txt)
+    end
+    assert_contains "$args_dump" "bar" "without-token: falls back to plain command claude with argv passthrough"
+
+    set -l stdout_content (cat $all_stdout)
+    assert_not_contains "$stdout_content" "FAKE-SA-TOKEN" "without-token: no SA token value ever printed"
+
+    cd $orig_pwd
+    rm -rf $tmp
+end
+
+test_with_sa_token
+test_without_sa_token
+
+if test $failures -eq 0
+    echo "All tests passed."
+    exit 0
+else
+    echo "$failures assertion(s) failed."
+    exit 1
+end

--- a/home-manager/home/file/op/claude.env.example
+++ b/home-manager/home/file/op/claude.env.example
@@ -1,0 +1,2 @@
+# ~/.config/op/claude.env として配置。op run が op:// 参照を service account で解決し GH_TOKEN 等を注入する。実 vault/item 名を書いた実ファイルはコミットしない
+GH_TOKEN=op://<vault>/<item>/token


### PR DESCRIPTION
Closes #69

## 概要
bg claude agent が sandbox 下で `~/.config/gh` 等の認証情報ディレクトリを読めず `gh` 認証に失敗する問題を、1Password Service Account 経由の secret 注入で解消する。

## 変更点
- `home-manager/home/file/fish/functions/claude.fish`: fish autoload wrapper。Keychain(`claude-op-sa`) から SA token を取得し `op run --env-file`(global `~/.config/op/claude.env` → repo-local `.op.env` の後勝ち layering)で `GH_TOKEN` 等を注入。子プロセス env からは `env -u OP_SERVICE_ACCOUNT_TOKEN` で SA token を除去。op 未検出/token 未設定/env-file 不在時は素の `command claude` にフォールバック。
- `home-manager/home/file/fish/functions/claude.test.fish`: fake op/security/claude を使う統合テスト(8 assertion, PASS)。
- `home-manager/home/file/op/claude.env.example`: `GH_TOKEN=op://<vault>/<item>/token` プレースホルダのみ。
- `home-manager/home/default.nix`: 上記 2 ファイルを home.file に登録。
- `.gitignore`: `.op.env` / `**/.op.env` を無視。
- `README.md`: SA 作成・Keychain 格納(128文字切れの罠)・env-file layering・疎通確認手順を追記。

## テスト
- 3 test files / 42 assertions PASS (claude.test.fish 8, credential-guard 25, stop-unfinished-guard 9)。
- evaluator verdict: pass (9/9 AC satisfied)。

## 注意 / 残タスク
- L1 (bg-sandbox capability recovery) の疎通確認は本 wrapper 導入後の手動検証に委ねる。適用には `nix run .#update` 後、README 手順で 1Password SA / Keychain entry のセットアップが必要。

🤖 dev-flow workflow で実装。https://claude.ai/code/session_01SD5Xb9VeQLDR2Vr4tyjpFS