### PR TITLE
fix(claude-fish): op run の TTY 喪失で対話起動が壊れる回帰を修正

### DIFF
--- a/home-manager/home/file/fish/functions/claude.fish
+++ b/home-manager/home/file/fish/functions/claude.fish
@@ -1,4 +1,12 @@
-function claude --description 'claude wrapped with 1Password service-account GH_TOKEN injection'
+# Returns success when claude should launch its interactive UI (both stdin and
+# stdout are TTYs). Split out so the test suite can override the TTY probe.
+if not functions -q __claude_wrapper_is_interactive
+    function __claude_wrapper_is_interactive
+        isatty stdin; and isatty stdout
+    end
+end
+
+function claude --description 'claude wrapped with 1Password service-account secret injection'
     if not command -v op >/dev/null 2>&1
         command claude $argv
         return
@@ -24,6 +32,40 @@ function claude --description 'claude wrapped with 1Password service-account GH_
         return
     end
 
+    if __claude_wrapper_is_interactive
+        # Interactive launch: `op run -- claude` would wrap the child's stdio in
+        # pipes for secret masking, stripping claude's controlling TTY and forcing
+        # it into non-interactive (--print) mode (see issue #69). Instead resolve
+        # the op:// references here and export only the declared secrets into this
+        # shell, then exec the real claude with its TTY intact.
+
+        # Collect the variable names declared across the env-files.
+        set -l keys
+        for ef in $env_files
+            set -l path (string replace -- --env-file= '' $ef)
+            for line in (cat $path 2>/dev/null)
+                set -l k (string match -rg '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=' -- $line)
+                test -n "$k"; and set -a keys $k
+            end
+        end
+
+        # Resolve op:// references once (outside any sandbox) and export only the
+        # declared keys. The SA token is dropped via `env -u` and is never a key,
+        # so it is never exported into this shell.
+        for kv in (OP_SERVICE_ACCOUNT_TOKEN=$sa_token op run $env_files -- env -u OP_SERVICE_ACCOUNT_TOKEN)
+            set -l pair (string split -m1 = -- $kv)
+            if contains -- $pair[1] $keys
+                set -gx $pair[1] $pair[2]
+            end
+        end
+
+        command claude $argv
+        return $status
+    end
+
+    # Non-interactive launch (bg agent / piped): keep op run so its secret masking
+    # stays active on the child's stdout/stderr. env inheritance reaches sandboxed
+    # child processes even where credential dirs are read-denied (issue #69).
     OP_SERVICE_ACCOUNT_TOKEN=$sa_token op run $env_files -- env -u OP_SERVICE_ACCOUNT_TOKEN command claude $argv
     return $status
 end

--- a/home-manager/home/file/fish/functions/claude.fish
+++ b/home-manager/home/file/fish/functions/claude.fish
@@ -49,6 +49,22 @@ function claude --description 'claude wrapped with 1Password service-account sec
             end
         end
 
+        # Snapshot each declared key's prior state so it can be restored once
+        # claude exits. Without this, the resolved secrets would stay exported
+        # for the rest of this login shell's lifetime and leak into every
+        # subsequent child process, not just this claude invocation.
+        set -l saved_was_set
+        set -l saved_values
+        for k in $keys
+            if set -q $k
+                set -a saved_was_set 1
+                set -a saved_values $$k
+            else
+                set -a saved_was_set 0
+                set -a saved_values ''
+            end
+        end
+
         # Resolve op:// references once (outside any sandbox) and export only the
         # declared keys. The SA token is dropped via `env -u` and is never a key,
         # so it is never exported into this shell.
@@ -60,7 +76,20 @@ function claude --description 'claude wrapped with 1Password service-account sec
         end
 
         command claude $argv
-        return $status
+        set -l exit_status $status
+
+        # Restore the parent shell's prior environment so the resolved secrets
+        # do not outlive this claude invocation.
+        for i in (seq (count $keys))
+            set -l k $keys[$i]
+            if test "$saved_was_set[$i]" = 1
+                set -gx $k $saved_values[$i]
+            else
+                set -e $k
+            end
+        end
+
+        return $exit_status
     end
 
     # Non-interactive launch (bg agent / piped): keep op run so its secret masking

--- a/home-manager/home/file/fish/functions/claude.test.fish
+++ b/home-manager/home/file/fish/functions/claude.test.fish
@@ -52,7 +52,7 @@ function make_fakebin --argument-names dir
         '  elif [[ "$a" == --env-file=* ]]; then' \
         '    env_files+=("${a#--env-file=}")' \
         '  fi' \
-        'done' \
+        done \
         'for f in "${env_files[@]}"; do' \
         '  if [ -f "$f" ]; then' \
         '    while IFS="=" read -r k v; do' \
@@ -60,9 +60,8 @@ function make_fakebin --argument-names dir
         '      export "$k=$v"' \
         '    done < "$f"' \
         '  fi' \
-        'done' \
-        'exec "${rest[@]}"' \
-        > $dir/op
+        done \
+        'exec "${rest[@]}"' >$dir/op
     chmod +x $dir/op
 
     # fake `security`: emits $FAKE_SA_TOKEN (may be empty) regardless of args.
@@ -70,17 +69,15 @@ function make_fakebin --argument-names dir
         '#!/usr/bin/env bash' \
         'if [ -n "$FAKE_SA_TOKEN" ]; then' \
         '  printf "%s" "$FAKE_SA_TOKEN"' \
-        'fi' \
-        'exit 0' \
-        > $dir/security
+        fi \
+        'exit 0' >$dir/security
     chmod +x $dir/security
 
     # fake `claude`: dumps its environment and argv for inspection.
     printf '%s\n' \
         '#!/usr/bin/env bash' \
         'env > "$FAKE_CLAUDE_ENV_DUMP"' \
-        'printf "%s\n" "$@" > "$FAKE_CLAUDE_ARGS_DUMP"' \
-        > $dir/claude
+        'printf "%s\n" "$@" > "$FAKE_CLAUDE_ARGS_DUMP"' >$dir/claude
     chmod +x $dir/claude
 end
 
@@ -89,6 +86,10 @@ end
 # strips OP_SERVICE_ACCOUNT_TOKEN, and passes argv through to real claude.
 # ---------------------------------------------------------------------------
 function test_with_sa_token
+    # Force the default (isatty) probe so this exercises the non-interactive path
+    # regardless of any override left by an earlier test.
+    functions -e __claude_wrapper_is_interactive
+
     set -l tmp (mktemp -d)
     set -l fakebin $tmp/bin
     make_fakebin $fakebin
@@ -124,10 +125,10 @@ function test_with_sa_token
     if test -f $tmp/args_dump.txt
         set args_dump (cat $tmp/args_dump.txt)
     end
-    assert_contains "$args_dump" "foo" "with-token: argv passed through to real claude"
+    assert_contains "$args_dump" foo "with-token: argv passed through to real claude"
 
     set -l stdout_content (cat $all_stdout)
-    assert_not_contains "$stdout_content" "FAKE-SA-TOKEN" "with-token: SA token value never printed to stdout/stderr"
+    assert_not_contains "$stdout_content" FAKE-SA-TOKEN "with-token: SA token value never printed to stdout/stderr"
 
     cd $orig_pwd
     rm -rf $tmp
@@ -138,6 +139,8 @@ end
 # `command claude $argv` without ever invoking op run.
 # ---------------------------------------------------------------------------
 function test_without_sa_token
+    functions -e __claude_wrapper_is_interactive
+
     set -l tmp (mktemp -d)
     set -l fakebin $tmp/bin
     make_fakebin $fakebin
@@ -164,17 +167,77 @@ function test_without_sa_token
     if test -f $tmp/args_dump.txt
         set args_dump (cat $tmp/args_dump.txt)
     end
-    assert_contains "$args_dump" "bar" "without-token: falls back to plain command claude with argv passthrough"
+    assert_contains "$args_dump" bar "without-token: falls back to plain command claude with argv passthrough"
 
     set -l stdout_content (cat $all_stdout)
-    assert_not_contains "$stdout_content" "FAKE-SA-TOKEN" "without-token: no SA token value ever printed"
+    assert_not_contains "$stdout_content" FAKE-SA-TOKEN "without-token: no SA token value ever printed"
 
     cd $orig_pwd
     rm -rf $tmp
 end
 
+# ---------------------------------------------------------------------------
+# Test 3: interactive launch (stdin+stdout TTY) -> wrapper does NOT wrap claude
+# in `op run` (which would strip its TTY). Instead it resolves op:// references,
+# exports only the declared secrets into the shell, and execs the real claude
+# with argv passthrough. GH_TOKEN is injected, SA token is never exported/printed.
+# ---------------------------------------------------------------------------
+function test_interactive
+    # Override the TTY probe to force the interactive branch (the test harness
+    # itself runs with stdout redirected, so isatty would otherwise be false).
+    function __claude_wrapper_is_interactive
+        return 0
+    end
+
+    set -l tmp (mktemp -d)
+    set -l fakebin $tmp/bin
+    make_fakebin $fakebin
+    mkdir -p $tmp/.config/op
+    echo "GH_TOKEN=fake-gh" >$tmp/.config/op/claude.env
+
+    set -l fake_token (printf 'FAKE-SA-TOKEN-%.0s0' (seq 200))
+
+    set -lx HOME $tmp
+    set -lx PATH $fakebin $PATH
+    set -lx FAKE_SA_TOKEN $fake_token
+    set -lx FAKE_CLAUDE_ENV_DUMP $tmp/env_dump.txt
+    set -lx FAKE_CLAUDE_ARGS_DUMP $tmp/args_dump.txt
+
+    source $func_file
+
+    set -l all_stdout $tmp/all_stdout.txt
+    set -l orig_pwd $PWD
+    cd $tmp
+    claude baz >$all_stdout 2>&1
+    set -l claude_status $status
+
+    assert_eq $claude_status 0 "interactive: wrapper exits 0"
+
+    set -l env_dump ""
+    if test -f $tmp/env_dump.txt
+        set env_dump (cat $tmp/env_dump.txt)
+    end
+    assert_contains "$env_dump" "GH_TOKEN=fake-gh" "interactive: GH_TOKEN exported into shell then inherited by claude"
+    assert_not_contains "$env_dump" "OP_SERVICE_ACCOUNT_TOKEN=" "interactive: SA token never exported to claude env"
+
+    set -l args_dump ""
+    if test -f $tmp/args_dump.txt
+        set args_dump (cat $tmp/args_dump.txt)
+    end
+    assert_contains "$args_dump" baz "interactive: argv passed through to real claude"
+
+    set -l stdout_content (cat $all_stdout)
+    assert_not_contains "$stdout_content" FAKE-SA-TOKEN "interactive: SA token value never printed to stdout/stderr"
+
+    cd $orig_pwd
+    set -e GH_TOKEN
+    functions -e __claude_wrapper_is_interactive
+    rm -rf $tmp
+end
+
 test_with_sa_token
 test_without_sa_token
+test_interactive
 
 if test $failures -eq 0
     echo "All tests passed."

--- a/home-manager/home/file/fish/functions/claude.test.fish
+++ b/home-manager/home/file/fish/functions/claude.test.fish
@@ -229,8 +229,61 @@ function test_interactive
     set -l stdout_content (cat $all_stdout)
     assert_not_contains "$stdout_content" FAKE-SA-TOKEN "interactive: SA token value never printed to stdout/stderr"
 
+    assert_eq (set -q GH_TOKEN; echo $status) 1 "interactive: GH_TOKEN not left exported in caller shell after claude exits"
+
     cd $orig_pwd
-    set -e GH_TOKEN
+    set -e GH_TOKEN 2>/dev/null
+    functions -e __claude_wrapper_is_interactive
+    rm -rf $tmp
+end
+
+# ---------------------------------------------------------------------------
+# Test 4: interactive launch when a declared key was already set in the caller
+# shell -> the wrapper must restore the prior value after claude exits, not
+# just unset it (secrets should not persist, but pre-existing state must not
+# be clobbered either).
+# ---------------------------------------------------------------------------
+function test_interactive_restores_prior_value
+    function __claude_wrapper_is_interactive
+        return 0
+    end
+
+    set -l tmp (mktemp -d)
+    set -l fakebin $tmp/bin
+    make_fakebin $fakebin
+    mkdir -p $tmp/.config/op
+    echo "GH_TOKEN=fake-gh" >$tmp/.config/op/claude.env
+
+    set -l fake_token (printf 'FAKE-SA-TOKEN-%.0s0' (seq 200))
+
+    set -lx HOME $tmp
+    set -lx PATH $fakebin $PATH
+    set -lx FAKE_SA_TOKEN $fake_token
+    set -lx FAKE_CLAUDE_ENV_DUMP $tmp/env_dump.txt
+    set -lx FAKE_CLAUDE_ARGS_DUMP $tmp/args_dump.txt
+
+    source $func_file
+
+    set -gx GH_TOKEN pre-existing-value
+
+    set -l all_stdout $tmp/all_stdout.txt
+    set -l orig_pwd $PWD
+    cd $tmp
+    claude qux >$all_stdout 2>&1
+    set -l claude_status $status
+    cd $orig_pwd
+
+    assert_eq $claude_status 0 "restore: wrapper exits 0"
+
+    set -l env_dump ""
+    if test -f $tmp/env_dump.txt
+        set env_dump (cat $tmp/env_dump.txt)
+    end
+    assert_contains "$env_dump" "GH_TOKEN=fake-gh" "restore: claude still sees the resolved GH_TOKEN during its run"
+
+    assert_eq "$GH_TOKEN" "pre-existing-value" "restore: caller shell's pre-existing GH_TOKEN value restored after claude exits"
+
+    set -e GH_TOKEN 2>/dev/null
     functions -e __claude_wrapper_is_interactive
     rm -rf $tmp
 end
@@ -238,6 +291,7 @@ end
 test_with_sa_token
 test_without_sa_token
 test_interactive
+test_interactive_restores_prior_value
 
 if test $failures -eq 0
     echo "All tests passed."


### PR DESCRIPTION
## 概要

`claude` fish wrapper（1Password service-account secret 注入、#69 / PR #70）が全サブコマンドを `op run` で包んでいたため、**対話起動できない回帰**を修正する。`op run` は secret masking のため子プロセスの stdio をパイプで包み、`claude` の controlling TTY を奪う。その結果 claude が対話 UI を起動できず非対話（`--print`）モードにフォールバックし、以下で即死していた。

```
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

`claude agents --cwd $(pwd)` も同様に `stdout is not a TTY` で失敗。#69 の L1 手動検証で判明した回帰。

## 原因

#69 の確定版ラッパーは `command claude agents ...`（bg spawn する `agents` 起動のみ）を wrap する設計だったが、PR #70 の実装は `command claude $argv`（全サブコマンド）に拡大しており、本来対象外だった**素の対話 `claude`** まで `op run` 経由になっていた。

## 変更点

- **対話起動時（stdin+stdout が TTY）**: `op run` で包まず、`op://` 参照を先に解決して**宣言済みの secret のみ**を親 fish に `set -gx` してから、素の `claude` を **TTY 付きで**起動。
  - 「env にさえ注入されれば sandbox 子に継承される」という #69 の目的（価値①=capability 回復）は `op run` で包むこと自体には依存しないため、この方式で維持される。
  - SA token は `env -u OP_SERVICE_ACCOUNT_TOKEN` で除外され、env-file の宣言キーにも含まれないため **shell に export されない**。
  - `claude` 起動前に各キーの旧値（未設定なら「未設定」という状態）を退避し、`claude` 終了直後にその値へ復元（もしくは `set -e` で削除）する。解決済み secret が親 fish の以降の寿命・以降の全子プロセスへ永続 export されたまま残らないよう、露出を **claude 起動セッションの間だけ**に限定する。
- **非対話起動時（bg agent / piped）**: 従来どおり `op run` で包み、secret masking を維持。
- 将来 project 単位で `GH_TOKEN` 以外の secret を増やす前提に合わせ、env-file で宣言された**全キーを対象にした汎用注入**にした。
- TTY 判定を `__claude_wrapper_is_interactive` ヘルパーに切り出し（テスト可能化）。

## セキュリティ

- `op` の解決は **sandbox の外（fish wrapper）で 1 回だけ**行う構造を維持（Claude の bash sandbox 内は keychain / 1Password ホストが遮断されるため sandbox 内で `op` は呼ばない）。
- 対話経路では `op run` の **secret masking が無効化**される（`isatty` 分岐で**対話起動時のみ**に限定したため、bg agent の自動経路では masking を維持）。
- 対話経路では解決済み secret を一時的に親 fish へ `set -gx` するため、`claude` 実行中はその shell の `set`/`env` から平文で参照できる。ただし `claude` 終了時に必ず旧値へ復元（未設定だった場合は `set -e`）するため、**露出は claude 起動セッションの間だけに限定**され、親シェルの以降の寿命・以降の子プロセスへは残留しない。#69 の脅威モデル（受動漏れ）上も許容範囲。

## テスト

`home-manager/home/file/fish/functions/claude.test.fish` — **17 assertions PASS**。

- 非対話経路（SA token あり）: GH_TOKEN 注入 / SA token 除外 / argv passthrough / SA token 非出力
- fallback（SA token なし）: 素の `command claude` / argv passthrough
- **対話経路**: secret を shell に export → claude が継承 / SA token 非 export / argv passthrough / SA token 非出力 / **claude 終了後に GH_TOKEN が親 shell に残留しないこと**
- **対話経路（復元、新規）**: 呼び出し前から GH_TOKEN が設定されていた場合、claude 実行中は解決済み値に差し替わりつつ、終了後は元の値へ復元されること

```
$ fish home-manager/home/file/fish/functions/claude.test.fish
...
All tests passed.
```

## 手動検証（レビュアー / マージ後）

実機で `claude`（引数なし）を叩き、対話 UI が起動すること。および `claude agents`・`echo x | claude -p` が壊れないこと。#69 の L1（bg-sandbox capability 回復）は本 wrapper 適用後に併せて実測。

Refs #69

