### PR TITLE
feat(fish): issue/PR を fzf 選択してブラウザで開く abbr を追加

### DIFF
--- a/home-manager/programs/common.nix
+++ b/home-manager/programs/common.nix
@@ -20,6 +20,10 @@
     # gh
     # githubブラウザページを開く
     ghb = "gh browse";
+    # issueをfzf選択してブラウザで開く
+    ghi = "gh issue list --limit 100 --state all | fzf --ansi --preview 'GH_FORCE_TTY=1 gh issue view {1}' --preview-window 'right,60%,wrap' | awk '{print $1}' | xargs gh issue view -w";
+    # PRをfzf選択してブラウザで開く
+    ghp = "gh pr list --limit 100 --state all | fzf --ansi --preview 'GH_FORCE_TTY=1 gh pr view {1}' --preview-window 'right,60%,wrap' | awk '{print $1}' | xargs gh pr view -w";
     # lazigit
     lg = "lazygit";
     # lazydocker


### PR DESCRIPTION
## 概要

GitHub の issue / PR を fzf でインクリメンタル選択し、ブラウザで開く fish abbr を2つ追加。

## 追加した abbr

| abbr | 動作 |
|------|------|
| `ghi` | `gh issue list --limit 100 --state all` を fzf 選択 → `gh issue view -w` でブラウザ表示 |
| `ghp` | `gh pr list --limit 100 --state all` を fzf 選択 → `gh pr view -w` でブラウザ表示 |

preview に `GH_FORCE_TTY=1 gh {issue,pr} view {1}` を使い、右60%ペインで内容をプレビュー。

## 反映

`nix run .#update` で反映。