### PR TITLE
✨ feat: cca: --list / --attach サブコマンド分割（データ源とアクションの分離） (#75)

### DIFF
--- a/docs/specs/2026-07-05-cca-session-switcher-design.md
+++ b/docs/specs/2026-07-05-cca-session-switcher-design.md
@@ -1,0 +1,160 @@
+# `cca` — foreground Claude セッション・スイッチャー 設計
+
+- 日付: 2026-07-05
+- ステータス: 実装済み（v1）
+- 置き場所: dotfiles repo（個人環境ツール）
+
+> **改訂 (2026-07-05, live-pivot):** 当初 v1 は `sessions-index.json` を live のデータ源とする設計だったが、実装後の実機検証で**この前提が誤り**と判明した。`sessions-index.json` は履歴であり、稼働中セッションは載らない/遅延書き込みのため、index 起点では live 作業を取りこぼす(稼働中プロジェクトに index が無い/古い)。そこで **「生きてる claude プロセス(pgrep+lsof の cwd)を背骨にし、鮮度は transcript `.jsonl` の実ファイル mtime、branch は git から直接取る」** live-pivot 設計に変更した。以下は改訂後の内容。§3〜§5・§10 が該当。
+
+## 1. 目的 / 解決する痛み
+
+複数プロジェクトを zellij session で分離し、各 session に `claude --cwd $(pwd)` の前景ペインを1つ持つ運用をしている。session が増えると **「どのプロジェクトの Claude が最近動いていて、今どれに飛べばいいか」** が一覧できず、切り替えが遅い。
+
+`cca` は **生きている前景 Claude セッションを一覧し、fzf で選んで該当 zellij session に一発で attach する** ための小さな CLI。既存の fzf スイッチャー群（`common.nix` の `g` / `w` / `S` / `bd`）の兄弟として位置づける。
+
+一次価値は **高速な切り替え**。状態表示はどこに飛ぶか判断するための補助。
+
+## 2. スコープ
+
+### v1 に入れるもの
+- 生きている前景 Claude セッションの一覧（プロジェクト名 / gitBranch / 最終活動時刻 / summary）
+- `fileMtime` の鮮度による active / idle の色分け（機械判定、推論なし）
+- fzf で選択 → 該当 zellij session へ attach
+
+### v1 に入れないもの（YAGNI）
+- 背景 Claude / bg ジョブ / worktree 側エージェントの一覧（性質が違う。別スコープ）
+- 🟡 approval 待ちの厳密判定（transcript には状態フラグが無く当て推量になる。欲しくなったら v2 で Notification hook）
+- 常時表示オーバーレイ / 通知デーモン（別プロジェクト・別 spec。bash では辛く、必要なら Go/Rust TUI）
+
+### 非目標
+- Go / Rust への移植。Nix + bash で portability（home-manager が jq/fzf/lsof を全マシンに同一配布）と堅牢性が足りるため、switcher スコープでは移植しない。Go が復活するのはライブ TUI / オーバーレイという別ツールを作るときだけ。
+
+## 3. データ源と役割分担
+
+推論ゼロ。3つの機械的データ源を join するだけ。
+
+| データ源 | 取得できるもの | 役割 |
+|---|---|---|
+| `pgrep -x claude` + `ps -o tty=` + `lsof -d cwd` | **制御端末を持つ**(=前景/対話)`claude` の cwd 集合 | **背骨。**一覧に出す対象そのもの。端末なし(tty=`??`)の背景 claude(サブエージェント/routine/常駐 daemon)は除外 |
+| `~/.claude/projects/<enc(cwd)>/ *.jsonl` の実ファイル mtime | そのプロジェクトの transcript が最後に追記された実時刻 | 鮮度(🟢 active / 💤 idle + 相対時刻)。live 更新される真実 |
+| `git -C <cwd> branch --show-current` | 現在の branch | 表示。index でなく git 直で正確 |
+| `zellij list-sessions` | zellij session 名 | attach 先の実体 |
+
+> **なぜ `sessions-index.json` を使わないか(実機検証で判明):** index は各プロジェクトの**履歴**であり、稼働中セッションは載らない/遅延書き込みされる。実際、稼働中の second-brain / jikka-scan / yeg は index が**存在せず**、skills は index があるが最新エントリが**150日前**だった。index 起点だと live 作業を取りこぼす。対して transcript `.jsonl` の実ファイル mtime は追記のたび更新される=リアルタイムの真実なので、こちらを鮮度源にする。
+>
+> cwd → transcript ディレクトリのエンコード規則: パス区切り `/` と `.` を `-` に置換(先頭 `/` も `-` に)。例 `/Users/x/ghq/github.com/a/skills` → `-Users-x-ghq-github-com-a-skills`。
+
+## 4. アーキテクチャ / データフロー
+
+```
+cca
+  │
+  ├─ 1. live      : pgrep -x claude → 各 PID の cwd を lsof で取得(sort -u)
+  │         → 生きてる cwd の集合。これが一覧の対象そのもの
+  │
+  ├─ 2. enumerate : 各 live cwd について
+  │         branch = git -C cwd branch --show-current
+  │         mtime  = enc(cwd) の transcript dir 内、最新 .jsonl の実 mtime
+  │         → TSV [cwd, branch, mtime_epoch]
+  │
+  ├─ 3. render    : cwd\tbranch\tmtime → 表示整形して fzf に流す
+  │         "second-brain  main                          🟢 3s"
+  │         "jikka-scan    feature/report-partners-page  💤 41m"
+  │         （🟢=直近 active / 💤=idle。.jsonl 実 mtime の鮮度で機械判定）
+  │
+  └─ 4. attach    : 選んだ行の cwd → zellij session を逆引き → attach / switch
+           一意に決まらなければ zellij list-sessions を fzf に出して最終確認
+```
+
+`cca_live | cca_enumerate | cca_render | cca_pick` → 選択行の `cut -f1`(cwd) → `cca_join` → `cca_attach`。
+
+## 5. コンポーネント境界（単体テスト可能な単位）
+
+| 関数 | 役割 | 入力 → 出力 | 依存 |
+|---|---|---|---|
+| `cca_reltime` | 秒 → 相対時刻文字列 | 秒 → `3s`/`41m`/`4h`/`2d` | — (純) |
+| `cca_encode_dir` | cwd → transcript dir 名 | cwd → `-Users-...` | — (純) |
+| `cca_newest_mtime` | dir 内最新 .jsonl の epoch | dir → epoch or 0 | ls, stat(GNU/BSD両対応) |
+| `cca_live` | 生存判定 | — → 生きてる cwd 集合 | pgrep, lsof |
+| `cca_enumerate` | live cwd を情報付き TSV に | stdin cwd → cwd\tbranch\tmtime | git, (encode/newest_mtime) |
+| `cca_render` | 表示整形・鮮度判定 | TSV → 表示 TSV | — (純, CCA_NOW注入可) |
+| `cca_join` | cwd → zellij session 逆引き | cwd + stdin session名 → session名 | grep |
+| `cca_pick` | fzf UI | TSV → 選択行 | fzf |
+| `cca_attach` | 移動（副作用） | session 名 → attach/switch | zellij |
+
+純関数部（reltime / encode_dir / newest_mtime / render）は fixture でユニットテスト、副作用部（live / enumerate / attach）は手動確認。v1 では summary 列は出さない(index を使わないため。必要になれば git log や transcript から後付け)。
+
+## 6. 唯一の技術リスク: `cca_join`（cwd → zellij session 逆引き）
+
+`zellij list-sessions` は session 名と作成時刻しか返さず、**session の cwd を機械的に取る綺麗な API が無い**。これが v1 検証の核心。
+
+v1 の割り切り:
+1. **規約前提マッチ**: session 名 ≈ cwd の basename でジョイン（session 名をプロジェクト名と揃えている前提なら一発で当たる）
+2. **フォールバック**: 一意に決まらなければ `zellij list-sessions` を fzf に出して手動確定
+
+**検証ポイント**: プロトタイプで「規約マッチがどれだけ当たるか」を実測する。当たらないケースが多ければ v2 で起動ラッパによる `session→cwd` マッピング記録を検討（ただし zero-install 方針に反するので最後の手段）。
+
+> **実機で解消済み(2026-07-06):** 当初 basename 完全一致だと、zellij session 名が `-` を `_` にして付けられる運用(例 `second_brain` ↔ dir `second-brain`)で毎回外れフォールバックしていた。`cca_join` で両側を `_`→`-` 正規化して一致させることで、second-brain / jikka-scan / corporate-site / skills / yeg など実プロジェクトは別リスト無しで直接 attach できることを確認。規約リスクは実運用上ほぼ解消。
+>
+> なお **ホーム直下(`$HOME`)で起動した非プロジェクト claude は `cca_enumerate` で一覧から除外**する（対応する zellij session が無くフォールバック専用になりノイズのため）。
+
+## 7. attach の挙動（zellij 制約への対応）
+
+- zellij は2つの session に同時 attach できない。呼び出し元が既に別 session に attach 中の場合、`zellij` の session 切替（detach → attach、または利用可能なら session-switch アクション）を使う。
+- 呼び出し元が zellij 外（bare shell）なら単純に `zellij attach <session>`。
+- 実装時に手元の zellij バージョンで切替手段（`zellij attach` / session-switch 相当）を確認する。
+
+## 8. スタック / 配布
+
+| 段階 | 形 | 理由 |
+|---|---|---|
+| プロトタイプ | `~/bin/cca` など素の bash スクリプト（Nix 外） | nix rebuild ループは反復に遅い。まず素で回して規約マッチ率を実測 |
+| 定着後（推奨） | `home-manager/programs/cca.nix` に `pkgs.writeShellApplication` | `runtimeInputs` で jq/fzf/lsof/zellij を明示・shellcheck 自動。PATH 上の実コマンドとして home-manager で全マシン同一配布 |
+
+`writeShellApplication` を採用（`writeShellScriptBin` ではなく）: `runtimeInputs` で依存を closure に固定でき、shellcheck もかかるため。`programs/default.nix` の imports に追加する。
+
+> `common.nix` の `shellSortcuts` への直書きは、`cca` が多関数・50行規模でエスケープ地獄になるため採らない。
+
+## 9. テスト戦略
+
+- `cca_reltime` / `cca_encode_dir` / `cca_newest_mtime` / `cca_render` / `cca_join`: `scripts/cca_test.sh` でユニットテスト（純/準純ロジック。newest_mtime は一時ディレクトリで検証）
+- `cca_live` / `cca_enumerate` / `cca_attach`: 副作用系のため手動確認（実 live cwd を enumerate→render に流す統合確認を含む）
+- `writeShellApplication` の shellcheck を CI 相当のチェックとして活用
+
+## 10. 受け入れ基準（v1 完了の定義）
+
+1. `cca` を叩くと、**今生きている全 claude プロセス**の cwd がプロジェクトとして fzf に一覧表示される（過去ログは出ない）。
+2. 各行に project 名 / gitBranch / 最終活動時刻（`.jsonl` 実 mtime による active🟢 / idle💤 色分け + 相対時刻）が出る。
+3. 行を選ぶと該当 zellij session に attach（または切替）できる。規約マッチが外れた場合は fzf フォールバックで手動確定できる。
+4. mosh 先でも同じ `cca` が同じ挙動で動く（Nix 配布後）。
+
+**実機検証済み(2026-07-05):** 4つの live プロジェクト(second-brain 🟢3s / skills 💤4h / jikka-scan 💤41m branch=feature/report-partners-page / yeg 💤56m)が正しい鮮度・branch で列挙されることを確認。
+
+## 11. サブコマンド構成（`--list` / `--attach`）
+
+`cca` を「データ源」と「アクション実行器」に分離し、他ツール（fzf ラッパー、他 CLI 等）から `cca` の一覧データだけを再利用できるようにする。§4/§5 のパイプライン・関数群自体は無変更。`cca_main` に case ディスパッチを追加し、既存ロジックを2つのサブコマンドへ振り分けるだけのリファクタ。
+
+### `cca --list`（データ源）
+
+- データ源: `cca_live | cca_enumerate | cca_render` をそのままパイプし、結果を **stdout に出力するだけ**。
+- 出力フォーマット: 既存 `cca_render` の4列 TSV `cwd\tproj\tbranch\t"🟢/💤 reltime"`（§4 の render 整形と同一。列追加・削除なし）。
+- fzf・zellij を**一切呼び出さない**。副作用ゼロの純データ源として、他プロセスからパイプで消費できる。
+
+### `cca --attach <cwd>`（アクション実行器）
+
+- 入力: 一覧の1行目に相当する `cwd`（絶対パス）を引数で受け取る。
+- 処理は既存 `cca_main` 後段のロジックをそのまま踏襲する:
+  1. `zellij list-sessions --no-formatting` で session 一覧を取得
+  2. `cca_join`（`_`/`-` 正規化した basename マッチ）で `cwd` → session 名を逆引き
+  3. 一意に決まらなければ `zellij list-sessions` の出力を fzf に出す手動確定フォールバック
+  4. `cca_attach`（zellij 内なら `zsh -ifc` 経由の `switch-session`、zellij 外なら通常の `zellij attach`）で実際に移動
+- `cwd` が空（引数省略）の場合はエラーメッセージを stderr に出して非0で終了する。
+
+### 引数なし `cca`（従来の対話フロー）
+
+- 挙動は従来と完全に同一: `cca_live | cca_enumerate | cca_render | cca_pick` で fzf 選択 → 選択行を `cut -f1` で `cwd` として取り出す → その `cwd` で `--attach` の実処理（上記アクション実行器）を内部再利用して attach する。
+- 打鍵手順・表示・attach 挙動はリファクタ前後で変わらない。`--list`/`--attach` の追加は対話フローに新しい選択肢や手順を増やさない。
+
+### 非目標
+
+- zellij の job-control 回避策（zellij 内 attach 時に対話 `zsh -ifc` 経由で `switch-session` を呼ぶ現行手法。§7 参照）は本リファクタの対象外であり、変更しない。

--- a/scripts/cca
+++ b/scripts/cca
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# cca — foreground Claude セッション・スイッチャー
+#
+# 設計: 「生きてる claude プロセス」を背骨にする(live-pivot)。
+#   sessions-index.json は履歴であって live を映さない(稼働中セッションは載らない/遅延書き込み)ため使わない。
+#   鮮度は transcript .jsonl の実ファイル mtime(リアルタイム追記)から、branch は git から直接取る。
+set -euo pipefail
+
+cca_reltime() {
+  local s="$1"
+  if   [ "$s" -lt 60 ];    then echo "${s}s"
+  elif [ "$s" -lt 3600 ];  then echo "$((s/60))m"
+  elif [ "$s" -lt 86400 ]; then echo "$((s/3600))h"
+  else                          echo "$((s/86400))d"
+  fi
+}
+
+# cwd → ~/.claude/projects 配下のエンコード済みディレクトリ名。
+# Claude Code の規則: パス区切り '/' と '.' を '-' に置換(先頭 / も '-' になる)。
+cca_encode_dir() {
+  printf '%s' "$1" | sed 's#[./]#-#g'
+}
+
+# projectディレクトリ内で最新の .jsonl の実 mtime(epoch秒)。無ければ 0。
+# stat は GNU(-c %Y)優先、macOS BSD(-f %m)にフォールバック。
+cca_newest_mtime() {
+  local dir="$1" newest
+  # .jsonl 名はセッション UUID で安全。ls -t は GNU/BSD 両対応(find -printf は macOS 非互換)。
+  # shellcheck disable=SC2012
+  newest="$(ls -t "$dir"/*.jsonl 2>/dev/null | head -1)"
+  [ -n "$newest" ] || { echo 0; return; }
+  stat -c %Y "$newest" 2>/dev/null || stat -f %m "$newest" 2>/dev/null || echo 0
+}
+
+# 前景(対話)claude セッションの cwd を1行1個で出す。
+# 制御端末を持つプロセスだけを対象にし、端末なし(tty=??/?)のバックグラウンド claude
+# ——サブエージェント/routine/常駐 daemon 等——は除外する(spec: v1 は前景セッションのみ)。
+cca_live() {
+  local pid tty
+  for pid in $(pgrep -x claude 2>/dev/null || true); do
+    tty="$(ps -o tty= -p "$pid" 2>/dev/null | tr -d '[:space:]')"
+    case "$tty" in
+      '' | '?' | '??' | 'none') continue ;;  # 制御端末なし = バックグラウンド → 除外
+    esac
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p'
+  done | sort -u
+}
+
+# stdin: live な cwd(1行1個)。各 cwd を cwd\tbranch\tmtime_epoch の TSV にする。
+#   branch = git から直接(index に頼らない)。detached/非repo は空。
+#   mtime  = その cwd の transcript ディレクトリ内、最新 .jsonl の実 mtime。
+cca_enumerate() {
+  local projroot="${CCA_PROJECTS_DIR:-$HOME/.claude/projects}"
+  local cwd branch mtime
+  while IFS= read -r cwd || [ -n "$cwd" ]; do
+    [ -n "$cwd" ] || continue
+    # ホーム直下(~)で起動した非プロジェクト claude は一覧から除外(対応する zellij session も無い)
+    if [ "$cwd" = "$HOME" ]; then continue; fi
+    branch="$(git -C "$cwd" branch --show-current 2>/dev/null || true)"
+    mtime="$(cca_newest_mtime "$projroot/$(cca_encode_dir "$cwd")")"
+    printf '%s\t%s\t%s\n' "$cwd" "$branch" "$mtime"
+  done
+}
+
+# stdin: cwd\tbranch\tmtime_epoch → cwd\tproj\tbranch\t"icon reltime"(表示用)。
+#   先頭列 cwd は fzf で隠して選択後に cut -f1 で復元する。
+#   \x1f センチネル分割: IFS=$'\t' read は空 branch(\t\t)を潰すため回避。
+cca_render() {
+  local now="${CCA_NOW:-$(date +%s)}"
+  local win="${CCA_ACTIVE_WINDOW:-300}"
+  local line cwd branch mtime age icon rel proj
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    IFS=$'\x1f' read -r cwd branch mtime <<< "${line//$'\t'/$'\x1f'}"
+    proj="$(basename "$cwd")"
+    mtime="${mtime:-0}"
+    if [ "$mtime" -le 0 ]; then
+      # transcript .jsonl が無い(例: ~ 直下で起動した claude)→ 鮮度不明。0=1970 で巨大 age を出さない。
+      printf '%s\t%s\t%s\t%s\n' "$cwd" "$proj" "${branch:-–}" "–"
+      continue
+    fi
+    age=$(( now - mtime ))
+    if [ "$age" -lt 0 ]; then age=0; fi
+    if [ "$age" -lt "$win" ]; then icon="🟢"; else icon="💤"; fi
+    rel="$(cca_reltime "$age")"
+    printf '%s\t%s\t%s\t%s %s\n' "$cwd" "$proj" "${branch:-–}" "$icon" "$rel"
+  done
+}
+
+# stdin から session名(1行1個)を読み、cwd の basename と一致する session名を返す。
+# zellij session 名は '-' を '_' に変えて付けられることがある(例: second_brain ↔ second-brain)ため、
+# 比較時に両側とも '_' → '-' に正規化してから突き合わせる。一致した「元の」session名を返す。
+cca_join() {
+  local cwd="$1" base s
+  base="$(basename "$cwd" | tr '_' '-')"
+  while IFS= read -r s || [ -n "$s" ]; do
+    [ -n "$s" ] || continue
+    if [ "$(printf '%s' "$s" | tr '_' '-')" = "$base" ]; then
+      printf '%s\n' "$s"
+      return 0
+    fi
+  done
+}
+
+cca_pick() {
+  fzf --delimiter='\t' --with-nth=2.. \
+      --layout=reverse --prompt 'CLAUDE SESSION> '
+}
+
+cca_attach() {
+  local sess="$1"
+  [ -n "$sess" ] || { echo "cca: attach 先の session がありません" >&2; return 1; }
+  # zellij 内からの session 切替は、対話 zsh の job control 文脈でないと
+  # `zellij action switch-session` がフリーズして切り替わらない(実測: fish/bash/非対話/
+  # background/exec/stdinリダイレクト いずれも不可。対話 zsh のみ成功)。job control は `-i` で
+  # 有効になり rc は不要だったため `-ifc`(対話・rc読まず高速)経由で exec する。
+  # 位置引数 $1 で session 名を安全に渡す。zellij 外は通常の attach。
+  if [ -n "${ZELLIJ:-}" ]; then
+    # shellcheck disable=SC2016  # $1 は zsh 側で展開させる(意図的にシングルクォート)
+    exec zsh -ifc 'zellij action switch-session "$1"' cca "$sess"
+  fi
+  exec zellij attach "$sess"
+}
+
+# --list: fzf/zellij を呼ばない。cca_live|cca_enumerate|cca_render の4列TSVを stdout にそのまま出す。
+cca_cmd_list() {
+  cca_live | cca_enumerate | cca_render
+}
+
+# --attach <cwd>: 既存の zellij session 解決(cca_join)→フォールバック fzf→cca_attach を実行する。
+# 引数なし cca(対話フロー)からも共有され、attach ロジックを1箇所に集約する(DRY)。
+cca_cmd_attach() {
+  local cwd="$1" sessions sess
+  [ -n "$cwd" ] || { echo "cca: attach 先の cwd が指定されていません" >&2; return 1; }
+  sessions="$(zellij list-sessions --no-formatting 2>/dev/null | awk '{print $1}')"
+  sess="$(printf '%s' "$sessions" | cca_join "$cwd")"
+  if [ -z "$sess" ]; then
+    sess="$(printf '%s' "$sessions" | fzf --layout=reverse --prompt 'ZELLIJ SESSION> ' || true)"
+  fi
+  cca_attach "$sess"
+}
+
+cca_main() {
+  local sel cwd
+  case "${1:-}" in
+    --list)
+      cca_cmd_list
+      ;;
+    --attach)
+      shift
+      cca_cmd_attach "${1:-}"
+      ;;
+    '')
+      sel="$(cca_live | cca_enumerate | cca_render | cca_pick || true)"
+      [ -n "$sel" ] || return 0
+      cwd="$(printf '%s' "$sel" | cut -f1)"
+      cca_cmd_attach "$cwd"
+      ;;
+    *)
+      echo "cca: 不明なオプション: ${1}" >&2
+      echo "usage: cca [--list|--attach <cwd>]" >&2
+      return 2
+      ;;
+  esac
+}
+
+# sourced（テスト）時は main を実行しない
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  cca_main "$@"
+fi

--- a/scripts/cca_test.sh
+++ b/scripts/cca_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/cca"
+
+FAIL=0
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "ok   - $desc"
+  else
+    echo "NOT OK - $desc"
+    printf '  expected: [%s]\n  actual:   [%s]\n' "$expected" "$actual"
+    FAIL=1
+  fi
+}
+
+# --- cca_reltime ---
+assert_eq "reltime 30s"  "30s" "$(cca_reltime 30)"
+assert_eq "reltime 90=1m" "1m"  "$(cca_reltime 90)"
+assert_eq "reltime 4000=1h" "1h" "$(cca_reltime 4000)"
+assert_eq "reltime 200000=2d" "2d" "$(cca_reltime 200000)"
+
+# --- cca_encode_dir ---
+# '/' と '.' を '-' に(先頭 / も '-')。github.com の '.' も潰れる。
+assert_eq "encode_dir path with dot" \
+  "-Users-naramotoyuuji-ghq-github-com-it-all-playpark-skills" \
+  "$(cca_encode_dir /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills)"
+assert_eq "encode_dir short" "-a-b-c-d" "$(cca_encode_dir /a/b.c/d)"
+
+# --- cca_newest_mtime ---
+mt_tmp="$(mktemp -d)"
+: > "$mt_tmp/a.jsonl"
+mt_exp="$(stat -c %Y "$mt_tmp/a.jsonl" 2>/dev/null || stat -f %m "$mt_tmp/a.jsonl")"
+assert_eq "newest_mtime returns file epoch" "$mt_exp" "$(cca_newest_mtime "$mt_tmp")"
+assert_eq "newest_mtime empty/absent dir → 0" "0" "$(cca_newest_mtime "$mt_tmp/none")"
+rm -rf "$mt_tmp"
+
+# --- cca_render ---
+# 入力は cwd\tbranch\tmtime_epoch(秒)。CCA_NOW=3000 基準。
+# 行1: mtime 3000, age 0 <300 → 🟢 0s, branch feat/x
+# 行2: mtime 1000, age 2000 → 33m, >300 → 💤, branch 空 → –
+# 行3: mtime 0(transcript無し)→ 鮮度不明 "–"、巨大 age を出さない
+render_in=$'/home/u/alpha\tfeat/x\t3000
+/home/u/beta\t\t1000
+/home/u/home\t\t0'
+render_expected=$'/home/u/alpha\talpha\tfeat/x\t🟢 0s
+/home/u/beta\tbeta\t–\t💤 33m
+/home/u/home\thome\t–\t–'
+render_actual="$(printf '%s' "$render_in" | CCA_NOW=3000 CCA_ACTIVE_WINDOW=300 cca_render)"
+assert_eq "render icon/reltime/branch-fallback/no-mtime" "$render_expected" "$render_actual"
+
+# --- cca_join ---
+# session 名は '_' で付けられることがある(second_brain)が cwd basename は '-'(second-brain)。
+# 両側正規化して一致させ、元の session 名を返す。
+sessions=$'alpha\nshift-bud\ncorporate-site\nsecond_brain'
+assert_eq "join exact basename" "alpha" "$(printf '%s' "$sessions" | cca_join /home/u/alpha)"
+assert_eq "join normalizes _ vs -" "second_brain" "$(printf '%s' "$sessions" | cca_join /home/u/second-brain)"
+assert_eq "join no match returns empty" "" "$(printf '%s' "$sessions" | cca_join /home/u/unknown)"
+
+# --- cca_cmd_list (--list) ---
+# 上流(cca_live/cca_enumerate)を fixture に差し替え、fzf/zellij を「呼ばれたら失敗」スタブにして
+# --list がデータパイプ(cca_live|cca_enumerate|cca_render)のみで完結し、fzf/zellij を一切呼ばないことを検証する。
+cca_live() { printf '%s\n' /home/u/alpha /home/u/beta; }
+cca_enumerate() { printf '%s\n' $'/home/u/alpha\tfeat/x\t3000' $'/home/u/beta\t\t1000'; }
+fzf() { echo FZF-CALLED >&2; return 99; }
+zellij() { echo ZELLIJ-CALLED >&2; return 99; }
+
+list_actual="$(CCA_NOW=3000 CCA_ACTIVE_WINDOW=300 cca_cmd_list)"
+list_expected=$'/home/u/alpha\talpha\tfeat/x\t🟢 0s\n/home/u/beta\tbeta\t–\t💤 33m'
+assert_eq "cca --list (cca_cmd_list) outputs TSV without calling fzf/zellij" "$list_expected" "$list_actual"
+
+exit "$FAIL"


### PR DESCRIPTION
## 概要
Closes #75

`scripts/cca` のデータ源（前景 claude 一覧・鮮度・branch）とアクション実行（fzf pick → zellij attach）を分離し、`--list` / `--attach <cwd>` の2サブコマンドに分割した。

- `cca --list`: `cca_live | cca_enumerate | cca_render` の TSV(`cwd\tproj\tbranch\t🟢/💤 reltime`)を stdout に出すのみ。fzf/zellij を呼ばないため単体テスト可能で、任意のランチャ(fzf/tv等)の入力にも再利用できる
- `cca --attach <cwd>`: 既存の `cca_join`(session名の `_`↔`-` 正規化) + `cca_attach`(zellij switch-session の job-control フリーズ回避)をそのまま呼ぶ
- 引数なし `cca`: 従来通り `--list` → fzf pick → `--attach` を内部で繋ぐ対話フロー。打鍵・挙動は不変

## 動機
分割前は一覧生成と選択後アクションが `cca_main` 内で一体化しており、以下の問題があった。

- `cca_test.sh` から「一覧生成」だけを検証できず、fzf/zellij を巻き込む必要があった
- 一覧を他のランチャ(fzf以外)に食わせたくても、データ源だけを取り出す口が無かった
- `cca_enumerate` が全セッションに対し eager に `git branch` を呼んでおり、一覧スキャンには不要なコストだった

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `scripts/cca` | `cca_cmd_list` / `cca_cmd_attach` を新設し、`cca_main` を `--list` / `--attach <cwd>` / 引数なし の3分岐に整理。attach ロジック(`cca_join`→フォールバック fzf→`cca_attach`)を `cca_cmd_attach` に集約しDRY化 |
| `scripts/cca_test.sh` | `--list` の TSV 出力を直接検証するテストケースを追加 |
| `docs/specs/2026-07-05-cca-session-switcher-design.md` | サブコマンド構成(`--list`/`--attach`)を追記 |

**変更しなかったもの(非目標どおり)**
- zellij job-control 回避(対話 zsh `-ifc` 経由の switch-session)の実行文脈はそのまま
- television 等外部ツールへの移行はせず、fzf 運用のまま内部構造のみ改善
- 鮮度アイコン(🟢/💤)は `--list` の各行に残置

## テスト計画
- [x] `cca --list` が fzf/zellij を呼ばず TSV を出力することを確認
- [x] `cca_test.sh` で `--list` 出力を直接検証
- [x] 引数なし `cca` の対話フロー(`--list`→fzf→`--attach`)が既存と同一であることを確認