### PR TITLE
feat: moshi-hook を nix-darwin(Homebrew) 管理下に追加

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -58,6 +58,16 @@ in
       cleanup = "uninstall"; # Brewfileにないものをアンインストール
       extraFlags = [ "--force-cleanup" ]; # cleanup実行時の確認を明示的に許可
     };
+    taps = [
+      # 追加のHomebrew tap
+      "rjyo/moshi" # moshi CLI / moshi-hook サービス
+    ];
+    brews = [
+      # インストールするformula（brew）のリスト
+      # moshi-hook: Moshiアプリ連携のhookサービス
+      # 初回のみ手動で「moshi-hook host setup」を実行する（Moshiアプリでのペアリングが前提のため自動化しない）
+      "moshi-hook"
+    ];
     casks = [
       # インストールするCaskアプリケーションのリスト
       "antigravity"


### PR DESCRIPTION
## 概要

`brew tap rjyo/moshi && brew install moshi-hook` を nix-darwin の宣言的 Homebrew 管理に移行。

## 変更内容
- `darwin/default.nix` の `homebrew` ブロックに以下を追加:
  - `taps`: `rjyo/moshi`
  - `brews`: `moshi-hook`

`onActivation.cleanup = "uninstall"` のため、宣言しておかないと次回 `nix run .#update` で削除される。tap/formula を nix 管理に含めることでこれを防ぎつつ再現性を確保。

## 手動作業（初回のみ）
`moshi-hook host setup` は Moshi アプリでのホストペアリングが前提の対話コマンドのため、activationScript では自動化せず手動実行とする:

```bash
nix run .#update      # tap + formula がインストールされる
moshi-hook host setup # Moshi アプリでペアリング後に実行
```

## 検証
- `nix fmt` 通過（treefmt）
- nix eval はサンドボックスの daemon-socket 制限で未実行。`taps`/`brews` は nix-darwin homebrew モジュールの標準オプション。