### PR TITLE
feat: 🎸 cc-launchでClaude Remote Controlを起動できるようにする

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -63,6 +63,10 @@ in
         source = ./file/zellij;
         recursive = true;
       };
+      ".config/cc-launch" = {
+        source = ./file/cc-launch;
+        recursive = true;
+      };
     };
 
     # Claude Code 設定を dotfiles/claude-code/ からシンボリックリンクで参照

--- a/home-manager/home/file/cc-launch/projects.tsv.template
+++ b/home-manager/home/file/cc-launch/projects.tsv.template
@@ -1,0 +1,8 @@
+# project	path	session	remote-control-name
+shift-bud	~/ghq/github.com/playpark-llc/shift-bud	shift-bud	shift-bud
+corporate-site	~/ghq/github.com/playpark-llc/corporate-site	corporate-site	corporate-site
+playpark-brain	~/ghq/github.com/playpark-llc/playpark-brain	playpark-brain	playpark-brain
+dotfiles	~/ghq/github.com/it-all-playpark/dotfiles	dotfiles	dotfiles
+skills	~/ghq/github.com/it-all-playpark/skills	skills	skills
+second-brain	~/ghq/github.com/it-all-playpark/second-brain	second-brain	second-brain
+yeg	~/ghq/github.com/playpark-llc/yeg	yeg	yeg

--- a/home-manager/programs/cc-launch.nix
+++ b/home-manager/programs/cc-launch.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+{
+  home.packages = [
+    (pkgs.writeShellApplication {
+      name = "cc-launch";
+      runtimeInputs = with pkgs; [
+        coreutils
+        gawk
+        ghq
+        git
+        gnugrep
+        gnused
+        lsof
+        procps
+        zellij
+      ];
+      text = builtins.readFile ../../scripts/cc-launch;
+    })
+  ];
+}

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -9,5 +9,6 @@
     ./yazi.nix
     ./neovim.nix
     ./cca.nix
+    ./cc-launch.nix
   ];
 }

--- a/scripts/cc-launch
+++ b/scripts/cc-launch
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cc_launch_usage() {
+  cat <<'USAGE'
+usage: cc-launch <project>
+       cc-launch --list
+
+Start a Claude Code Remote Control session for a local project.
+
+Project resolution order:
+  1. ~/.config/cc-launch/projects.tsv
+  2. ~/.config/cc-launch/projects.tsv.template
+  3. ghq repo basename, only when it resolves to exactly one repo
+
+projects.tsv format:
+  project<TAB>path<TAB>session-name<TAB>remote-control-name
+USAGE
+}
+
+cc_launch_die() {
+  echo "cc-launch: $*" >&2
+  exit 1
+}
+
+cc_launch_validate_name() {
+  local kind="$1" value="$2"
+  case "$value" in
+    '')
+      cc_launch_die "$kind is empty"
+      ;;
+    *[!A-Za-z0-9._-]*)
+      cc_launch_die "$kind contains unsupported characters: $value"
+      ;;
+  esac
+}
+
+cc_launch_expand_path() {
+  local path="$1"
+  case "$path" in
+    [~])
+      printf '%s\n' "$HOME"
+      ;;
+    [~]/*)
+      printf '%s/%s\n' "$HOME" "${path#\~/}"
+      ;;
+    *)
+      printf '%s\n' "$path"
+      ;;
+  esac
+}
+
+cc_launch_config_files() {
+  printf '%s\n' \
+    "$HOME/.config/cc-launch/projects.tsv" \
+    "$HOME/.config/cc-launch/projects.tsv.template"
+}
+
+cc_launch_lookup_config() {
+  local project="$1" file line found=1
+
+  while IFS= read -r file; do
+    [ -f "$file" ] || continue
+    line="$(
+      awk -F '\t' -v key="$project" '
+        $0 ~ /^[[:space:]]*($|#)/ { next }
+        $1 == key { print; found = 1; exit }
+        END { if (!found) exit 1 }
+      ' "$file"
+    )" || true
+    if [ -n "${line:-}" ]; then
+      printf '%s\n' "$line"
+      return 0
+    fi
+  done < <(cc_launch_config_files)
+
+  return "$found"
+}
+
+cc_launch_lookup_ghq() {
+  local project="$1" matches count
+
+  command -v ghq >/dev/null 2>&1 || return 1
+  matches="$(ghq list --full-path 2>/dev/null | awk -F/ -v key="$project" '$NF == key { print }')"
+  [ -n "$matches" ] || return 1
+
+  count="$(printf '%s\n' "$matches" | awk 'NF { n++ } END { print n + 0 }')"
+  if [ "$count" -ne 1 ]; then
+    echo "cc-launch: project '$project' matched multiple ghq repos:" >&2
+    printf '%s\n' "$matches" >&2
+    echo "cc-launch: add it to ~/.config/cc-launch/projects.tsv to disambiguate" >&2
+    exit 1
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$project" "$matches" "$project" "$project"
+}
+
+cc_launch_resolve_project() {
+  local project="$1" line key dir session remote_name rest
+
+  line="$(cc_launch_lookup_config "$project" || true)"
+  if [ -z "${line:-}" ]; then
+    line="$(cc_launch_lookup_ghq "$project" || true)"
+  fi
+  [ -n "${line:-}" ] || cc_launch_die "unknown project: $project"
+
+  IFS=$'\t' read -r key dir session remote_name rest <<< "$line"
+  [ -z "${rest:-}" ] || cc_launch_die "too many columns for project: $project"
+  [ "$key" = "$project" ] || cc_launch_die "config key mismatch: $key"
+
+  dir="$(cc_launch_expand_path "$dir")"
+  session="${session:-$project}"
+  remote_name="${remote_name:-$session}"
+
+  cc_launch_validate_name "project" "$project"
+  cc_launch_validate_name "session name" "$session"
+  cc_launch_validate_name "Remote Control name" "$remote_name"
+  [ -d "$dir" ] || cc_launch_die "project directory does not exist: $dir"
+
+  printf '%s\t%s\t%s\t%s\n' "$project" "$dir" "$session" "$remote_name"
+}
+
+cc_launch_list() {
+  local file
+  while IFS= read -r file; do
+    [ -f "$file" ] || continue
+    awk -F '\t' '
+      $0 ~ /^[[:space:]]*($|#)/ { next }
+      { print $1 "\t" $2 "\t" ($3 == "" ? $1 : $3) "\t" ($4 == "" ? ($3 == "" ? $1 : $3) : $4) }
+    ' "$file"
+    return 0
+  done < <(cc_launch_config_files)
+
+  command -v ghq >/dev/null 2>&1 || return 0
+  ghq list --full-path 2>/dev/null | awk -F/ '{ print $NF "\t" $0 "\t" $NF "\t" $NF }'
+}
+
+cc_launch_claude_bin() {
+  local mise_claude="$HOME/.local/share/mise/installs/claude-code/latest/claude"
+
+  if command -v claude >/dev/null 2>&1; then
+    command -v claude
+    return 0
+  fi
+  if [ -x "$mise_claude" ]; then
+    printf '%s\n' "$mise_claude"
+    return 0
+  fi
+
+  cc_launch_die "claude binary not found"
+}
+
+cc_launch_session_exists() {
+  local session="$1"
+  zellij list-sessions --no-formatting 2>/dev/null | awk '{ print $1 }' | grep -Fxq "$session"
+}
+
+cc_launch_has_live_claude() {
+  local dir="$1" pid cwd
+
+  for pid in $(pgrep -x claude 2>/dev/null || true); do
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+    [ "$cwd" = "$dir" ] && return 0
+  done
+
+  return 1
+}
+
+cc_launch_start() {
+  local project="$1" resolved dir session remote_name claude_bin log run_args=()
+
+  cc_launch_validate_name "project" "$project"
+  resolved="$(cc_launch_resolve_project "$project")"
+  IFS=$'\t' read -r project dir session remote_name <<< "$resolved"
+
+  claude_bin="$(cc_launch_claude_bin)"
+  log="${TMPDIR:-/tmp}/cc-launch-${session}.log"
+
+  if cc_launch_has_live_claude "$dir"; then
+    printf 'cc-launch: already running project=%s session=%s dir=%s\n' "$project" "$session" "$dir"
+    return 0
+  fi
+
+  if ! cc_launch_session_exists "$session"; then
+    {
+      printf '[cc-launch] creating zellij session %s cwd=%s\n' "$session" "$dir"
+      zellij attach --create-background "$session" options --default-cwd "$dir"
+    } >>"$log" 2>&1
+    run_args+=(--in-place)
+  fi
+
+  {
+    printf '[cc-launch] starting Claude Remote Control name=%s cwd=%s\n' "$remote_name" "$dir"
+    zellij --session "$session" run "${run_args[@]}" --name claude-remote --cwd "$dir" -- \
+      "$claude_bin" --remote-control "$remote_name"
+  } >>"$log" 2>&1
+
+  printf 'cc-launch: started project=%s session=%s remote=%s dir=%s log=%s\n' \
+    "$project" "$session" "$remote_name" "$dir" "$log"
+}
+
+cc_launch_main() {
+  case "${1:-}" in
+    -h | --help)
+      cc_launch_usage
+      ;;
+    --list)
+      cc_launch_list
+      ;;
+    '')
+      cc_launch_usage >&2
+      return 2
+      ;;
+    --*)
+      cc_launch_die "unknown option: $1"
+      ;;
+    *)
+      cc_launch_start "$1"
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  cc_launch_main "$@"
+fi


### PR DESCRIPTION
## 概要
- iPhoneショートカットのSSH実行からClaude Code Remote Controlを起動する `cc-launch` を追加
- `ghq` の既存ローカルrepoをもとに、`shift-bud` などのproject pathをtemplate化
- Home Managerで `cc-launch` と `.config/cc-launch` templateを配布

## 動機
Remote ControlはMac側で起動中のClaude Codeセッションが前提になるため、iPhoneから1タップで対象projectのzellij sessionとClaude Remote Controlを用意できる入口が必要だった。

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `scripts/cc-launch` | project解決、zellij background session作成、`claude --remote-control` 起動を実装 |
| `home-manager/programs/cc-launch.nix` | `cc-launch` を `writeShellApplication` で配布 |
| `home-manager/programs/default.nix` | `cc-launch` moduleをimport |
| `home-manager/home/default.nix` | `.config/cc-launch` templateをHome Manager管理に追加 |
| `home-manager/home/file/cc-launch/projects.tsv.template` | 既存local repoの実パスに基づくproject allow-list templateを追加 |

## テスト計画
- [x] `bash -n scripts/cc-launch`
- [x] `cc_launch_resolve_project shift-bud`
- [x] `nix build path:$PWD#homeConfigurations.naramotoyuuji-darwin.activationPackage --no-link --show-trace`
- [ ] `nix flake check path:$PWD --show-trace` は既存の `scripts/cca_test.sh` formatting差分で失敗

## 補足
- `playpark` というrepo名はlocal repoに存在しなかったため、aliasは追加していない
- `flake.lock` の既存変更はこのPRに含めていない
