### PR TITLE
fix(cc-launch): Remote Control 判定を --remote-control プロセスに限定

### DIFF
--- a/scripts/cc-launch
+++ b/scripts/cc-launch
@@ -155,10 +155,16 @@ cc_launch_session_exists() {
   zellij list-sessions --no-formatting 2>/dev/null | awk '{ print $1 }' | grep -Fxq "$session"
 }
 
-cc_launch_has_live_claude() {
+cc_launch_has_live_remote_control() {
   local dir="$1" pid cwd
 
   for pid in $(pgrep -x claude 2>/dev/null || true); do
+    # Only a Remote Control claude counts. A plain interactive session in the
+    # same dir (e.g. active editing) must not block launching Remote Control.
+    case " $(ps -o args= -p "$pid" 2>/dev/null) " in
+      *' --remote-control '*) ;;
+      *) continue ;;
+    esac
     cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
     [ "$cwd" = "$dir" ] && return 0
   done
@@ -176,8 +182,8 @@ cc_launch_start() {
   claude_bin="$(cc_launch_claude_bin)"
   log="${TMPDIR:-/tmp}/cc-launch-${session}.log"
 
-  if cc_launch_has_live_claude "$dir"; then
-    printf 'cc-launch: already running project=%s session=%s dir=%s\n' "$project" "$session" "$dir"
+  if cc_launch_has_live_remote_control "$dir"; then
+    printf 'cc-launch: Remote Control already running project=%s session=%s dir=%s\n' "$project" "$session" "$dir"
     return 0
   fi
 


### PR DESCRIPTION
## 概要
`cc-launch <project>` が、同じ dir で**通常の Claude Code セッションを開いて作業中**だと `already running` と誤判定し、Remote Control を起動できなかった問題を修正。

## 背景 / 再現
iPhone ショートカット → `cc-launch dotfiles` 実行時に:
```
cc-launch: already running project=dotfiles session=dotfiles dir=.../dotfiles
```
と出て `claude --remote-control` が起動せず、mobile の Claude アプリから参照できなかった。`dotfiles` リポジトリで dev セッションを開いていたことが原因。`shift-bud`（claude 非稼働）では正常に起動・参照できることを確認済み。

## 原因
`cc_launch_has_live_claude` は「その dir にいる `claude` プロセス」を無条件に稼働中とみなしていた。Remote Control とは無関係な通常の編集セッションまで検知して起動をブロックしていた。

## 変更
- `cc_launch_has_live_claude` → `cc_launch_has_live_remote_control` にリネームし、`ps -o args=` で **`--remote-control` 付きプロセスに限定**して判定
- 単語境界（前後スペース）でマッチし、`--remote-control-session-name-prefix` 単独は誤検知しない
- メッセージを `Remote Control already running ...` に更新（冪等性は維持）

## テスト
- [x] `bash -n scripts/cc-launch`
- [x] 引数マッチのロジック単体確認（plain/`--resume`/prefix単独 → SKIP、`--remote-control [name]` → MATCH）
- [ ] shellcheck / nix build はサンドボックスの nix キャッシュ制限で本環境では未実行（CI に委譲）