### PR TITLE
feat(claude-code): bg/sandbox の自動完遂性を強化

### DIFF
--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -40,6 +40,7 @@ Conflict: Safety > Scope > Quality > Speed
 - **process substitution `<(…)` を避ける**。`diff <(a) <(b)` 等は sandbox が `/dev/fd/*` を塞ぐため失敗する。一旦 tempfile に落として `diff f1 f2` にする
 - **network は `sandbox.network.allowedDomains` のホストのみ**到達可能。未許可ホストは即失敗 → 必要なら settings.json に追加してから実行（推測で叩かない）
 - sandbox で塞がれても `dangerouslyDisableSandbox` は policy で無効。回避不能なら失敗を報告し、settings 調整を提案する（勝手に緩めない）
+- **gh を内部で呼ぶ skill スクリプトは「先頭トークン＝スクリプトパス」の bare 形で呼ぶ**。`excludedCommands` は先頭トークンでマッチするため、`cd X && script`・`bash script`・`VAR=x script` の前置が付くと除外が外れて sandbox 内実行になり、中の gh が `~/.config/gh` を denyRead で読めず fatal（keyring token も securityd 経由で sandbox 内から取得不可）。`cd &&`/env 前置はパターンで塞げないので呼び出し側で回避する
 
 ## Failure Investigation
 🔴 Root cause analysis always. Never skip/disable tests or validation.

--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -34,6 +34,13 @@ Conflict: Safety > Scope > Quality > Speed
 ## Workspace Hygiene
 - Clean temporary files and build artifacts after use
 
+## Sandbox Hygiene
+🟡 sandbox 有効時（bg/remote 含む）に多発する失敗をコマンド側で回避する:
+- **一時ファイルは `/tmp` 直書き禁止**。`$TMPDIR`（bg では `$CLAUDE_JOB_DIR/tmp`）を使う。素の `/tmp/foo` は書込み不許可で `Operation not permitted`
+- **process substitution `<(…)` を避ける**。`diff <(a) <(b)` 等は sandbox が `/dev/fd/*` を塞ぐため失敗する。一旦 tempfile に落として `diff f1 f2` にする
+- **network は `sandbox.network.allowedDomains` のホストのみ**到達可能。未許可ホストは即失敗 → 必要なら settings.json に追加してから実行（推測で叩かない）
+- sandbox で塞がれても `dangerouslyDisableSandbox` は policy で無効。回避不能なら失敗を報告し、settings 調整を提案する（勝手に緩めない）
+
 ## Failure Investigation
 🔴 Root cause analysis always. Never skip/disable tests or validation.
 

--- a/claude-code/container.settings.json
+++ b/claude-code/container.settings.json
@@ -365,6 +365,7 @@
   "enabledPlugins": {},
   "extraKnownMarketplaces": {},
   "language": "ja",
+  "askUserQuestionTimeout": "10m",
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": false,
   "agentPushNotifEnabled": false

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -469,6 +469,7 @@
     "enabled": true,
     "failIfUnavailable": true,
     "allowUnsandboxedCommands": false,
+    "autoAllowBashIfSandboxed": true,
     "network": {
       "allowedDomains": [
         "github.com",
@@ -539,6 +540,7 @@
     ]
   },
   "tui": "fullscreen",
+  "askUserQuestionTimeout": "10m",
   "skipWorkflowUsageWarning": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -535,6 +535,10 @@
       "/Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/*",
       "bash /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/*",
       "python3 /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/*",
+      "bash $HOME/.claude/skills/*",
+      "python3 $HOME/.claude/skills/*",
+      "bash $HOME/ghq/github.com/it-all-playpark/skills/*",
+      "python3 $HOME/ghq/github.com/it-all-playpark/skills/*",
       "codex:*",
       "zernio:*"
     ]


### PR DESCRIPTION
## 背景
bg agent を sandbox 環境で自動実行すると tool use 失敗や停止が頻発する件の調査対応。実 journal/logs から失敗パターンを実証し、「セキュリティ担保しつつ自動でやりきる」方向で設定を調整した。

## 実証した失敗パターン（journal/logs より）
| 種別 | ログ実物 | 原因 |
|---|---|---|
| プロセス置換 | `diff: /dev/fd/12: Operation not permitted` | sandbox が `/dev/fd/*` を遮断。`diff <(…) <(…)` が全滅 |
| `/tmp` 直書き | `cat > /tmp/insert1.txt` 拒否 | allowWrite は `/tmp/claude`・`$TMPDIR` のみ |
| network | GSC API `*.googleapis.com` 遮断で「!で自分で実行」に迂回 | allowedDomains 外は即失敗 |
| 認証 | （過去対応済）bg 失敗の 99% が `gh` | `op run --env-file` + GH_TOKEN で解消済 |

`Operation not permitted` は journal 全体で 300件超。

## 変更内容
- **`sandbox.autoAllowBashIfSandboxed: true`** — sandbox 内 Bash を無確認実行。sandbox 自体を security 境界とし、`allowUnsandboxedCommands: false` / deny リスト / auto 分類器はそのまま維持（脱出口は作らない）。permission プロンプト由来の停止を削減
- **`askUserQuestionTimeout: "10m"`** — bg/remote で画面が見えず AskUserQuestion に答えられない時、10分後に既定（推奨）選択で自動継続し停止しない。settings.json / container.settings.json 両方に適用
- **`RULES.md` に Sandbox Hygiene 追記** — `/tmp` 直書き禁止（`$TMPDIR`/`$CLAUDE_JOB_DIR/tmp` を使う）、process substitution 回避（tempfile 経由）、未許可ホストを推測で叩かない。実 journal で頻発した失敗をコマンド側で予防

## セキュリティ影響
- deny リスト（`rm -rf`/`curl`/`sudo`/prod push 等）は全て有効のまま。sandbox 境界も維持
- `autoAllowBashIfSandboxed` は **sandbox 内**コマンドのみ無確認化。sandbox の write 範囲（cwd + allowlist）と network allowlist が引き続き封じ込める
- `askUserQuestionTimeout` は全セッション共通。10分アイドル時のみ発火するため、対話中の即答フローには実質影響しない

## ⚠️ 別途手動対応が必要（settings では不可）
作業中の「フォルダにアクセスしていいか」ダイアログは **macOS TCC のシステムダイアログ**であり、settings.json では抑止できない。remote-control では画面が見えず永久に詰まる。

**対処:** System Settings → Privacy & Security → **Full Disk Access** に、bg agent を起動するアプリ/バイナリを追加する（ターミナルアプリ、および必要なら claude/node のバイナリ）。これで Documents/Desktop 等の TCC 保護フォルダへのアクセス時のダイアログが事前許可され消える。

`tccutil` では付与できず（SIP 保護）、GUI 操作 or MDM(PPPC) プロファイルが必要なため、このPRには含めていない。

### 補足: FDA は mise 更新をまたいで維持される（署名照合）
`claude` は Developer-ID 署名済み（`Identifier=com.anthropic.claude-code` / `TeamIdentifier=Q6L2SF6YDW`）。TCC は署名済みバイナリを**パスではなく designated requirement（identifier + TeamID）で照合**するため、mise が毎日 version を上げてパスが変わっても FDA 付与は切れない。→ バイナリを一度追加すれば恒久。version 非依存の wrapper は exec 後の実バイナリ署名で判定されるため無意味。
