### PR TITLE
fix(codex): Codex hook script の欠落を修復

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -7,6 +7,7 @@ This directory stores shared Codex configuration managed by dotfiles.
 - `config.base.toml`: shared defaults merged into `~/.codex/config.toml`
 - `config.local.toml.template`: template for local-only overrides/secrets
 - `prompts/`, `policy/`: static assets synced as symlinks
+- `hooks/`: Codex hook scripts synced as symlinks for existing `~/.codex/hooks.json`
 - `rules/default.rules`: baseline template copied once to `~/.codex/rules/default.rules`
 
 ## Runtime and secret separation
@@ -14,6 +15,7 @@ This directory stores shared Codex configuration managed by dotfiles.
 - Local-only files: `~/.codex/config.local.toml`, `~/.codex/rules/default.rules`
 - Generated file: `~/.codex/config.toml` (rebuilt on each Home Manager activation)
 - Runtime files such as `auth.json`, `history.jsonl`, `sessions/` are not managed here.
+- `~/.codex/hooks.json` is runtime-managed because Codex stores hook trust hashes for it. Dotfiles only ensures referenced scripts under `~/.codex/hooks/` exist.
 
 ## Migration behavior
 
@@ -39,3 +41,9 @@ On first activation:
 - Avoid `sandbox_mode = "danger-full-access"` as a shared default. Use it only per-invocation when an external sandbox already exists.
 - Prefix rules are literal prefix matches. `["git", "push"]` does not match `git -C <path> push ...`.
 - `~/.codex/rules/default.rules` is local-only and copied only once. If you already have a local rules file, updates in `dotfiles/codex/rules/default.rules` will not overwrite it automatically.
+
+## Hook troubleshooting
+
+Codex reports PreToolUse/PostToolUse failures when `~/.codex/hooks.json` references scripts that do not exist under `~/.codex/hooks/`. Home Manager activation now symlinks the supported hook scripts from `codex/hooks/` without replacing `hooks.json`, so existing trusted hashes remain valid.
+
+Some lifecycle hooks are intentionally no-op placeholders until Codex-specific behavior is defined. They exist to keep stale runtime hook references from failing.

--- a/codex/hooks/memory-monitor.py
+++ b/codex/hooks/memory-monitor.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""No-op Codex PostToolUse hook.
+
+Kept to satisfy existing ~/.codex/hooks.json installations that reference this
+file. Runtime memory monitoring behavior is not defined for Codex here.
+"""
+
+import sys
+
+sys.stdin.read()
+sys.exit(0)

--- a/codex/hooks/permission-journal.sh
+++ b/codex/hooks/permission-journal.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PermissionRequest hook for Codex: log classifier prompts to ~/.codex/log.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  cat >/dev/null 2>&1 || true
+  exit 0
+fi
+
+INPUT=$(cat || true)
+[[ -n $INPUT ]] || exit 0
+
+CODEX_DIR="${CODEX_HOME:-${HOME}/.codex}"
+LOG_DIR="$CODEX_DIR/log"
+LOG_FILE="$LOG_DIR/permission-requests.jsonl"
+mkdir -p "$LOG_DIR"
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // .tool // "unknown"' 2>/dev/null || echo "unknown")
+
+case "$TOOL" in
+Bash)
+  DETAIL=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .input.command // empty' 2>/dev/null | head -c 500)
+  ;;
+Read | Write | Edit | MultiEdit)
+  DETAIL=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .input.file_path // empty' 2>/dev/null | head -c 500)
+  ;;
+WebFetch)
+  DETAIL=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // .input.url // empty' 2>/dev/null | head -c 500)
+  ;;
+*)
+  DETAIL=$(printf '%s' "$INPUT" | jq -c '.tool_input // .input // {}' 2>/dev/null | head -c 500)
+  ;;
+esac
+
+PROJECT=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+SESSION=$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")
+
+jq -n -c \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg tool "$TOOL" \
+  --arg detail "$DETAIL" \
+  --arg project "$PROJECT" \
+  --arg session "$SESSION" \
+  '{ts: $ts, tool: $tool, detail: $detail, project: $project, session: $session}' \
+  >>"$LOG_FILE"

--- a/codex/hooks/posttool-secret-mask.sh
+++ b/codex/hooks/posttool-secret-mask.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Codex: redact secrets from Bash stdout/stderr.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  cat >/dev/null 2>&1 || true
+  exit 0
+fi
+
+INPUT=$(cat || true)
+[[ -n $INPUT ]] || exit 0
+
+if [[ ${CODEX_HOOK_DEBUG:-0} == 1 ]]; then
+  {
+    printf '=== %s tool=%s ===\n' "$(date -Iseconds 2>/dev/null || date)" "$(printf '%s' "$INPUT" | jq -r '.tool_name // .tool // "?"')"
+    printf 'INPUT_FULL: %s\n\n' "$INPUT"
+  } >>"${TMPDIR:-/tmp}/codex-secret-mask-debug.log"
+fi
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // .tool // empty' 2>/dev/null || true)
+
+mask_text() {
+  perl -0777 -pe '
+    s/-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z ]+ )?PRIVATE KEY-----/[REDACTED:PRIVATE_KEY_BLOCK]/g;
+    s/\bAKIA[0-9A-Z]{16}\b/[REDACTED:AWS_ACCESS_KEY_ID]/g;
+    s/\bgithub_pat_[A-Za-z0-9_]{82,}/[REDACTED:GITHUB_PAT]/g;
+    s/\bgh[pousr]_[A-Za-z0-9]{36,255}\b/[REDACTED:GITHUB_TOKEN]/g;
+    s/\bsk-ant-[A-Za-z0-9_-]{20,}/[REDACTED:ANTHROPIC_KEY]/g;
+    s/\bsk_(?:live|test)_[A-Za-z0-9]{24,}/[REDACTED:STRIPE_KEY]/g;
+    s/\bsk-(?:proj-)?[A-Za-z0-9_-]{32,}/[REDACTED:SK_API_KEY]/g;
+    s/\bAIza[0-9A-Za-z_-]{30,}/[REDACTED:GOOGLE_API_KEY]/g;
+    s/\bxox[baprs]-[A-Za-z0-9-]{20,}/[REDACTED:SLACK_TOKEN]/g;
+    s/\bxapp-\d+-[A-Z0-9]+-\d+-[A-Za-z0-9]{20,}/[REDACTED:SLACK_APP_TOKEN]/g;
+    s/\bvck_[A-Za-z0-9]{24,}/[REDACTED:VERCEL_TOKEN]/g;
+    s/\bnapi_[A-Za-z0-9_-]{32,}/[REDACTED:NEON_API_KEY]/g;
+    s/\bhf_[A-Za-z0-9]{30,}/[REDACTED:HUGGINGFACE_TOKEN]/g;
+    s/\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/[REDACTED:JWT]/g;
+    s{\b([a-zA-Z][a-zA-Z0-9+.\-]*://)([^:/@\s]*):([^@/\s]+)@}{${1}${2}:[REDACTED:URL_CRED]\@}g;
+    s/(^|[\s])([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSPHRASE|CREDENTIAL|BEARER|SALT)[A-Z0-9_]*)=(?!\[REDACTED:)([^\s\r\n]{16,})($|[\s])/$1$2=[REDACTED:ENV_SECRET]$4/gm;
+    s/(^|[\s])([A-Za-z0-9_]*(?i:token|key|secret|password|passphrase|credential|bearer|salt)[A-Za-z0-9_]*)=(?!\[REDACTED:)([^\s\r\n]{16,})($|[\s])/$1$2=[REDACTED:ENV_SECRET]$4/gm;
+    s/("(?:[A-Za-z0-9_]*(?i:token|key|secret|password|credential|bearer|salt)[A-Za-z0-9_]*)"\s*:\s*")(?!\[REDACTED:)[^"\r\n]{12,}"/${1}[REDACTED:JSON_SECRET]"/g;
+  '
+}
+
+if [[ $TOOL_NAME == Bash ]]; then
+  STDOUT=$(printf '%s' "$INPUT" | jq -r '.tool_response.stdout // .response.stdout // ""' 2>/dev/null || true)
+  STDERR=$(printf '%s' "$INPUT" | jq -r '.tool_response.stderr // .response.stderr // ""' 2>/dev/null || true)
+
+  if [[ -z $STDOUT && -z $STDERR ]]; then
+    exit 0
+  fi
+
+  MASKED_STDOUT=$(printf '%s' "$STDOUT" | mask_text)
+  MASKED_STDERR=$(printf '%s' "$STDERR" | mask_text)
+
+  if [[ $MASKED_STDOUT == "$STDOUT" && $MASKED_STDERR == "$STDERR" ]]; then
+    exit 0
+  fi
+
+  printf '%s' "$INPUT" | jq \
+    --arg stdout "$MASKED_STDOUT" \
+    --arg stderr "$MASKED_STDERR" '
+      {
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          updatedToolOutput: ((.tool_response // .response // {}) + {stdout: $stdout, stderr: $stderr})
+        }
+      }
+    '
+  exit 0
+fi
+
+exit 0

--- a/codex/hooks/pre-compact-dump.sh
+++ b/codex/hooks/pre-compact-dump.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Codex PreCompact hook placeholder.
+#
+# The old runtime hooks.json may reference this path. Keep it present and
+# successful, but avoid Claude-specific session dump behavior.
+
+set -euo pipefail
+
+cat >/dev/null 2>&1 || true
+exit 0

--- a/codex/hooks/pretool-bash-credential-guard.sh
+++ b/codex/hooks/pretool-bash-credential-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook for Codex: detect production credential exposure.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  cat >/dev/null 2>&1 || true
+  exit 0
+fi
+
+INPUT=$(cat || true)
+[[ -n $INPUT ]] || exit 0
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // .tool // empty' 2>/dev/null || true)
+if [[ $TOOL != "Bash" ]]; then
+  exit 0
+fi
+
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .input.command // empty' 2>/dev/null || true)
+[[ -n $CMD ]] || exit 0
+
+emit_ask() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# $PROD_XXX / ${PRODUCTION_XXX} / $LIVE_XXX.
+if printf '%s' "$CMD" | grep -qE '\$\{?(PROD|PRODUCTION|LIVE)_[A-Z0-9_]+'; then
+  MATCH=$(printf '%s' "$CMD" | grep -oE '\$\{?(PROD|PRODUCTION|LIVE)_[A-Z0-9_]+' | head -1)
+  emit_ask "prod credential env var を検知: ${MATCH}"
+fi
+
+# .env.production / .env.prod references.
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]/"'"'"'=])\.env\.(production|prod)([[:space:]"'"'"';|&<>]|$)'; then
+  MATCH=$(printf '%s' "$CMD" | grep -oE '\.env\.(production|prod)' | head -1)
+  emit_ask "prod env ファイル参照を検知: ${MATCH}"
+fi
+
+# aws --profile values containing prod.
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])aws([[:space:]]|$)'; then
+  PROFILE=$(printf '%s' "$CMD" | grep -oE -- '--profile[= ][^[:space:]]+' | head -1 | sed -E 's/^--profile[= ]//')
+  if [[ -n $PROFILE ]] && printf '%s' "$PROFILE" | grep -qiE 'prod'; then
+    emit_ask "aws prod profile を検知: --profile ${PROFILE}"
+  fi
+fi
+
+exit 0

--- a/codex/hooks/pretool-bash-credential-guard.sh
+++ b/codex/hooks/pretool-bash-credential-guard.sh
@@ -45,9 +45,11 @@ fi
 
 # aws --profile values containing prod.
 if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])aws([[:space:]]|$)'; then
-  PROFILE=$(printf '%s' "$CMD" | grep -oE -- '--profile[= ][^[:space:]]+' | head -1 | sed -E 's/^--profile[= ]//')
-  if [[ -n $PROFILE ]] && printf '%s' "$PROFILE" | grep -qiE 'prod'; then
-    emit_ask "aws prod profile を検知: --profile ${PROFILE}"
+  if printf '%s' "$CMD" | grep -qE -- '--profile[= ]'; then
+    PROFILE=$(printf '%s' "$CMD" | grep -oE -- '--profile[= ][^[:space:]]+' | head -1 | sed -E 's/^--profile[= ]//')
+    if [[ -n $PROFILE ]] && printf '%s' "$PROFILE" | grep -qiE 'prod'; then
+      emit_ask "aws prod profile を検知: --profile ${PROFILE}"
+    fi
   fi
 fi
 

--- a/codex/hooks/session-start-replay.sh
+++ b/codex/hooks/session-start-replay.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Codex SessionStart hook placeholder.
+#
+# The old runtime hooks.json may reference this path. Keep it present and
+# successful, but avoid Claude-specific context replay behavior.
+
+set -euo pipefail
+
+cat >/dev/null 2>&1 || true
+exit 0

--- a/codex/hooks/stop-unfinished-guard.sh
+++ b/codex/hooks/stop-unfinished-guard.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Codex Stop hook placeholder.
+#
+# The old runtime hooks.json may reference this path. Keep it present and
+# successful, but avoid Claude-specific stop blocking behavior.
+
+set -euo pipefail
+
+cat >/dev/null 2>&1 || true
+exit 0

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -216,6 +216,29 @@ in
         cp "$DOTFILES_CODEX/rules/default.rules" "$rules_target"
       fi
 
+      # hooks.json は Codex runtime が trust state を持つためここでは上書きしない。
+      # ただし既存 hooks.json が参照する ~/.codex/hooks/* は dotfiles から補完する。
+      # 参照先が欠けると PreToolUse/PostToolUse が毎回失敗するため、hook scripts は managed symlink にする。
+      if [ -d "$DOTFILES_CODEX/hooks" ]; then
+        hooks_dir="$CODEX_DIR/hooks"
+        mkdir -p "$hooks_dir"
+        for f in "$DOTFILES_CODEX"/hooks/*.py "$DOTFILES_CODEX"/hooks/*.sh; do
+          if [ -f "$f" ]; then
+            base="$(basename "$f")"
+            case "$base" in
+              *.test.sh) continue ;;
+            esac
+            target="$hooks_dir/$base"
+            if [ -e "$target" ] && [ ! -L "$target" ]; then
+              backup="$hooks_dir/$base.backup.$(date +%Y%m%d%H%M%S)"
+              echo "Backing up existing Codex hook $target to $backup"
+              mv "$target" "$backup"
+            fi
+            ln -sfn "$f" "$target"
+          fi
+        done
+      fi
+
       # base config をシンボリックリンクで同期
       if [ -f "$CODEX_DIR/config.base.toml" ] && [ ! -L "$CODEX_DIR/config.base.toml" ]; then
         rm "$CODEX_DIR/config.base.toml"

--- a/tests/codex-hooks.test.sh
+++ b/tests/codex-hooks.test.sh
@@ -75,6 +75,35 @@ else
   fail "pretool credential guard detects prod env" "unexpected output: $pretool_out"
 fi
 
+set +e
+aws_no_profile_out="$(
+  jq -n '{tool_name:"Bash", tool_input:{command:"aws s3 ls"}}' |
+    "$HOOK_DIR/pretool-bash-credential-guard.sh"
+)"
+aws_no_profile_rc=$?
+set -e
+if [[ $aws_no_profile_rc -eq 0 ]] &&
+  [[ -z "$(printf '%s' "$aws_no_profile_out" | jq -r '.hookSpecificOutput.permissionDecision // empty')" ]]; then
+  pass "pretool credential guard passes aws command without --profile"
+else
+  fail "pretool credential guard passes aws command without --profile" \
+    "rc=$aws_no_profile_rc output=$aws_no_profile_out"
+fi
+
+set +e
+benign_out="$(
+  jq -n '{tool_name:"Bash", tool_input:{command:"ls -la"}}' |
+    "$HOOK_DIR/pretool-bash-credential-guard.sh"
+)"
+benign_rc=$?
+set -e
+if [[ $benign_rc -eq 0 ]] &&
+  [[ -z "$(printf '%s' "$benign_out" | jq -r '.hookSpecificOutput.permissionDecision // empty')" ]]; then
+  pass "pretool credential guard passes benign command"
+else
+  fail "pretool credential guard passes benign command" "rc=$benign_rc output=$benign_out"
+fi
+
 posttool_out="$(
   jq -n --arg stdout 'TOKEN=ghp_1234567890123456789012345678901234567890' \
     '{tool_name:"Bash", tool_response:{stdout:$stdout, stderr:""}}' |

--- a/tests/codex-hooks.test.sh
+++ b/tests/codex-hooks.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Smoke tests for Codex hook wrappers managed by dotfiles.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK_DIR="$REPO_ROOT/codex/hooks"
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/codex-hooks-test.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "        $2"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("$1: $2")
+}
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name" "command failed: $*"
+  fi
+}
+
+echo "=== Codex hook wrapper tests ==="
+
+for hook in \
+  pretool-bash-credential-guard.sh \
+  posttool-secret-mask.sh \
+  permission-journal.sh \
+  pre-compact-dump.sh \
+  session-start-replay.sh \
+  stop-unfinished-guard.sh \
+  memory-monitor.py; do
+  if [[ -x "$HOOK_DIR/$hook" ]]; then
+    pass "$hook is executable"
+  else
+    fail "$hook is executable" "missing or not executable: $HOOK_DIR/$hook"
+  fi
+done
+
+run_test "shell syntax" bash -n \
+  "$HOOK_DIR/pretool-bash-credential-guard.sh" \
+  "$HOOK_DIR/posttool-secret-mask.sh" \
+  "$HOOK_DIR/permission-journal.sh" \
+  "$HOOK_DIR/pre-compact-dump.sh" \
+  "$HOOK_DIR/session-start-replay.sh" \
+  "$HOOK_DIR/stop-unfinished-guard.sh"
+
+if rg -q 'claude-code|\.claude|CLAUDE_' "$HOOK_DIR"; then
+  fail "Codex hooks do not reference Claude runtime paths" "unexpected Claude reference under $HOOK_DIR"
+else
+  pass "Codex hooks do not reference Claude runtime paths"
+fi
+
+pretool_out="$(
+  jq -n '{tool_name:"Bash", tool_input:{command:"echo $PROD_DATABASE_URL"}}' |
+    "$HOOK_DIR/pretool-bash-credential-guard.sh"
+)"
+if [[ $(printf '%s' "$pretool_out" | jq -r '.hookSpecificOutput.permissionDecision // empty') == "ask" ]]; then
+  pass "pretool credential guard detects prod env"
+else
+  fail "pretool credential guard detects prod env" "unexpected output: $pretool_out"
+fi
+
+posttool_out="$(
+  jq -n --arg stdout 'TOKEN=ghp_1234567890123456789012345678901234567890' \
+    '{tool_name:"Bash", tool_response:{stdout:$stdout, stderr:""}}' |
+    "$HOOK_DIR/posttool-secret-mask.sh"
+)"
+if printf '%s' "$posttool_out" | jq -e '.hookSpecificOutput.updatedToolOutput.stdout | contains("[REDACTED:GITHUB_TOKEN]")' >/dev/null; then
+  pass "posttool secret mask redacts token"
+else
+  fail "posttool secret mask redacts token" "unexpected output: $posttool_out"
+fi
+
+CODEX_HOME="$TMPROOT/codex" "$HOOK_DIR/permission-journal.sh" <<'JSON'
+{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"git status"}}
+JSON
+if [[ -s "$TMPROOT/codex/log/permission-requests.jsonl" ]]; then
+  pass "permission journal writes under CODEX_HOME"
+else
+  fail "permission journal writes under CODEX_HOME" "missing log"
+fi
+
+printf '{}' | "$HOOK_DIR/memory-monitor.py"
+pass "memory monitor no-op exits cleanly"
+
+for hook in pre-compact-dump.sh session-start-replay.sh stop-unfinished-guard.sh; do
+  printf '{}' | "$HOOK_DIR/$hook"
+  pass "$hook no-op exits cleanly"
+done
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ $FAIL -gt 0 ]]; then
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## 概要

- `~/.codex/hooks.json` が参照する `~/.codex/hooks/*` の実体が欠け、PreToolUse/PostToolUse などが失敗する問題に対応
- Home Manager activation で `codex/hooks/` の Codex hook script を `~/.codex/hooks/` に symlink するように変更
- `~/.codex/hooks.json` は Codex runtime の trust state を持つため上書きせず、参照先 script だけを管理
- Codex hook 用の smoke test を追加

## 動機

Codex の sandbox 環境で tool use 前後の hook 失敗が頻発していた。調査したところ、runtime 管理の `~/.codex/hooks.json` が複数の hook script を参照している一方で、`~/.codex/hooks/` 配下の script 実体が存在しない状態だった。`hooks.json` を dotfiles から上書きすると trust hash を壊す可能性があるため、runtime ファイルは維持しつつ、参照先 script を dotfiles 管理で補完する。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `home-manager/home/default.nix` | `codex/hooks/*.sh` / `*.py` を `~/.codex/hooks/` へ symlink する activation 処理を追加 |
| `codex/hooks/*` | Codex 用 hook script を追加。未定義の lifecycle hook は no-op placeholder として失敗を防止 |
| `codex/README.md` | `hooks.json` は runtime 管理、script 実体は dotfiles 管理という方針を追記 |
| `tests/codex-hooks.test.sh` | hook script の実行権限、構文、redaction、journal、no-op 挙動を検証 |

## テスト計画

- [x] `bash tests/codex-hooks.test.sh`
- [x] `jq empty "$HOME/.codex/hooks.json" && bash -n codex/hooks/*.sh tests/codex-hooks.test.sh`
- [x] `XDG_CACHE_HOME="$TMPDIR/nix-cache-$USER" nix eval --impure --expr 'let flake = builtins.getFlake (toString ./.); in flake.homeConfigurations.naramotoyuuji-darwin.activationPackage.drvPath'`
- [ ] `nix flake check` は既存の `scripts/cca_test.sh` の treefmt 差分で失敗（今回変更とは別件）
