### PR TITLE
feat(claude-code): worktree isolation で node_modules/.cache を symlink 化

### DIFF
--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -455,6 +455,12 @@
       }
     ]
   },
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      ".cache"
+    ]
+  },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "telegram@claude-plugins-official": true,


### PR DESCRIPTION
## 概要

bg agent を並列で worktree isolation 走らせる際、worktree ごとに `node_modules` を実コピーすると disk 逼迫と install/生成コストがかかる。v2.1.202 で追加された `worktree.symlinkDirectories` を `claude-code/settings.json` に設定し、親 repo から symlink して共有する。

## 変更

```json
"worktree": {
  "symlinkDirectories": ["node_modules", ".cache"]
}
```

## 裏取り

- `worktree.symlinkDirectories` は Claude Code **v2.1.202** の zod schema に正式実装済み（binary strings で確認、update-config skill の Full Settings JSON Schema にも掲載）
- 説明: *"Directories to symlink from main repository to worktrees to avoid disk bloat. Must be explicitly configured - no directories are symlinked by default."*
- **相対パスのみ**（path-traversal / 絶対パスはガードで拒否）、対象 dir が存在しない repo（例: dotfiles 自体）では realpath 失敗で自動 skip
- 適用範囲: `--worktree` / `EnterWorktree` / agent isolation

## 反映方法

`~/.claude/settings.json` は本ファイルへの symlink（`home-manager/home/default.nix:111`）なので、**次セッションから即反映**。symlink 張り直しの `nix run .#update` は content 反映には不要。

## 注意

- symlink 先を worktree 内で書き換えると親 repo にも波及する。生成物専用の `node_modules` / `.cache` に限定しているため安全。build 出力（`dist` / `.next`）は user の作業ツリーと race しうるため**あえて除外**した。
- monorepo の nested `packages/*/node_modules` は top-level symlink 対象外（root hoist 前提）。

出典: second-brain/news/cc-tips-2026-07-08.md