### PR TITLE
fix(flake): starship の darwin ビルド失敗を修正し update に自動ロールバックを追加

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783458499,
-        "narHash": "sha256-a8whUXG4ThsZNjL92cH4wbl+/dt8CbT/F0zJsfhzFbM=",
+        "lastModified": 1783800036,
+        "narHash": "sha256-jncDHDD8REkePWvQmfH+ScPHxLL8LN4Hd/KjCdlLgD0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "53ebbdc405acc04acd9bb73ccca462b51ddb8c6d",
+        "rev": "0992a2948749a61d54065e96df26d75d1b1da50f",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,22 @@
                     old.preBuild;
               });
             })
+            # starship 1.26.0 は darwin で cctools ld64 がクラッシュしビルド失敗する
+            # (nixpkgs#540450, ld64 の libc++ hardening 問題)。
+            # upstream fix (nixpkgs#540463) と同じく lld でリンクして回避。
+            # nixpkgs#540463 が nixos-unstable channel に到達したら削除可。
+            (_final: prev: {
+              starship =
+                if prev.stdenv.hostPlatform.isDarwin then
+                  prev.starship.overrideAttrs (old: {
+                    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.llvmPackages.lld ];
+                    env = (old.env or { }) // {
+                      NIX_CFLAGS_LINK = "-fuse-ld=lld";
+                    };
+                  })
+                else
+                  prev.starship;
+            })
           ];
         }
       );
@@ -226,12 +242,31 @@
               BACKUP_EXT="backup-$(date +%Y%m%d%H%M%S)"
 
               echo "Updating flake for user: $USERNAME..."
+              LOCK_BACKUP=$(mktemp)
+              cp flake.lock "$LOCK_BACKUP"
               nix flake update
+
+              # 更新後の入力でビルド検証し、失敗したら flake.lock をロールバックする。
+              # nixos-unstable は darwin 全パッケージのビルド成功を保証しないため、
+              # 壊れた rev を踏んだ場合は既知の正常な入力のまま switch を続行する。
+              verify_or_rollback() {
+                echo "Verifying build with updated inputs..."
+                if nix build --no-link "$@"; then
+                  rm -f "$LOCK_BACKUP"
+                else
+                  echo "WARNING: updated inputs failed to build. Rolling back flake.lock to the previous (working) revision..."
+                  mv "$LOCK_BACKUP" flake.lock
+                fi
+              }
 
               # システムタイプに基づいて適切な設定を使用
               if [[ "$(uname)" == "Darwin" ]]; then
                 # macOS系の場合
                 echo "Detected macOS environment"
+                verify_or_rollback \
+                  ".#homeConfigurations.''${USERNAME}-darwin.activationPackage" \
+                  ".#darwinConfigurations.MyMBP-''${USERNAME}.system"
+
                 echo "Updating home-manager..."
                 nix run home-manager -- -b "$BACKUP_EXT" --flake .#''${USERNAME}-darwin switch
 
@@ -240,18 +275,22 @@
               else
                 # Linux系の場合（WSLを含む）
                 echo "Detected Linux environment"
-                echo "Updating home-manager..."
 
                 # アーキテクチャを検出
                 ARCH=$(uname -m)
                 if [[ "$ARCH" == "x86_64" ]]; then
-                  nix run home-manager -- -b "$BACKUP_EXT" --flake .#''${USERNAME}-linux-x86 switch
+                  SUFFIX="linux-x86"
                 elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
-                  nix run home-manager -- -b "$BACKUP_EXT" --flake .#''${USERNAME}-linux-arm switch
+                  SUFFIX="linux-arm"
                 else
                   echo "Unsupported architecture: $ARCH"
                   exit 1
                 fi
+
+                verify_or_rollback ".#homeConfigurations.''${USERNAME}-$SUFFIX.activationPackage"
+
+                echo "Updating home-manager..."
+                nix run home-manager -- -b "$BACKUP_EXT" --flake .#''${USERNAME}-$SUFFIX switch
               fi
 
               echo "Update complete!"
@@ -270,12 +309,35 @@
               BACKUP_EXT="backup-$(date +%Y%m%d%H%M%S)"
 
               echo "Updating flake for all users..."
+              LOCK_BACKUP=$(mktemp)
+              cp flake.lock "$LOCK_BACKUP"
               nix flake update
+
+              # 更新後の入力でビルド検証し、失敗したら flake.lock をロールバックする。
+              # nixos-unstable は darwin 全パッケージのビルド成功を保証しないため、
+              # 壊れた rev を踏んだ場合は既知の正常な入力のまま switch を続行する。
+              verify_or_rollback() {
+                echo "Verifying build with updated inputs..."
+                if nix build --no-link "$@"; then
+                  rm -f "$LOCK_BACKUP"
+                else
+                  echo "WARNING: updated inputs failed to build. Rolling back flake.lock to the previous (working) revision..."
+                  mv "$LOCK_BACKUP" flake.lock
+                fi
+              }
 
               # システムタイプに基づいて処理
               if [[ "$(uname)" == "Darwin" ]]; then
                 # macOS系の場合
                 echo "Detected macOS environment"
+
+                # 全ユーザー分のビルドをまとめて検証
+                VERIFY_TARGETS=()
+                for USERNAME in "''${USERNAMES[@]}"; do
+                  VERIFY_TARGETS+=(".#homeConfigurations.''${USERNAME}-darwin.activationPackage")
+                  VERIFY_TARGETS+=(".#darwinConfigurations.MyMBP-''${USERNAME}.system")
+                done
+                verify_or_rollback "''${VERIFY_TARGETS[@]}"
 
                 # 各ユーザーのhome-managerとnix-darwin設定を更新
                 for USERNAME in "''${USERNAMES[@]}"; do
@@ -300,6 +362,13 @@
                   echo "Unsupported architecture: $ARCH"
                   exit 1
                 fi
+
+                # 全ユーザー分のビルドをまとめて検証
+                VERIFY_TARGETS=()
+                for USERNAME in "''${USERNAMES[@]}"; do
+                  VERIFY_TARGETS+=(".#homeConfigurations.''${USERNAME}-$SUFFIX.activationPackage")
+                done
+                verify_or_rollback "''${VERIFY_TARGETS[@]}"
 
                 # 各ユーザーのhome-manager設定を更新
                 for USERNAME in "''${USERNAMES[@]}"; do

--- a/home-manager/programs/cca.nix
+++ b/home-manager/programs/cca.nix
@@ -3,7 +3,17 @@
   home.packages = [
     (pkgs.writeShellApplication {
       name = "cca";
-      runtimeInputs = with pkgs; [ jq fzf lsof zellij coreutils gnugrep gnused gawk procps ];
+      runtimeInputs = with pkgs; [
+        jq
+        fzf
+        lsof
+        zellij
+        coreutils
+        gnugrep
+        gnused
+        gawk
+        procps
+      ];
       text = builtins.readFile ../../scripts/cca;
       # 本体末尾の `if [ "${BASH_SOURCE[0]}" = "$0" ]` ガードにより cca_main が実行される
     })

--- a/scripts/cca_test.sh
+++ b/scripts/cca_test.sh
@@ -17,8 +17,8 @@ assert_eq() {
 }
 
 # --- cca_reltime ---
-assert_eq "reltime 30s"  "30s" "$(cca_reltime 30)"
-assert_eq "reltime 90=1m" "1m"  "$(cca_reltime 90)"
+assert_eq "reltime 30s" "30s" "$(cca_reltime 30)"
+assert_eq "reltime 90=1m" "1m" "$(cca_reltime 90)"
 assert_eq "reltime 4000=1h" "1h" "$(cca_reltime 4000)"
 assert_eq "reltime 200000=2d" "2d" "$(cca_reltime 200000)"
 
@@ -31,7 +31,7 @@ assert_eq "encode_dir short" "-a-b-c-d" "$(cca_encode_dir /a/b.c/d)"
 
 # --- cca_newest_mtime ---
 mt_tmp="$(mktemp -d)"
-: > "$mt_tmp/a.jsonl"
+: >"$mt_tmp/a.jsonl"
 mt_exp="$(stat -c %Y "$mt_tmp/a.jsonl" 2>/dev/null || stat -f %m "$mt_tmp/a.jsonl")"
 assert_eq "newest_mtime returns file epoch" "$mt_exp" "$(cca_newest_mtime "$mt_tmp")"
 assert_eq "newest_mtime empty/absent dir → 0" "0" "$(cca_newest_mtime "$mt_tmp/none")"
@@ -64,8 +64,14 @@ assert_eq "join no match returns empty" "" "$(printf '%s' "$sessions" | cca_join
 # --list がデータパイプ(cca_live|cca_enumerate|cca_render)のみで完結し、fzf/zellij を一切呼ばないことを検証する。
 cca_live() { printf '%s\n' /home/u/alpha /home/u/beta; }
 cca_enumerate() { printf '%s\n' $'/home/u/alpha\tfeat/x\t3000' $'/home/u/beta\t\t1000'; }
-fzf() { echo FZF-CALLED >&2; return 99; }
-zellij() { echo ZELLIJ-CALLED >&2; return 99; }
+fzf() {
+  echo FZF-CALLED >&2
+  return 99
+}
+zellij() {
+  echo ZELLIJ-CALLED >&2
+  return 99
+}
 
 list_actual="$(CCA_NOW=3000 CCA_ACTIVE_WINDOW=300 cca_cmd_list)"
 list_expected=$'/home/u/alpha\talpha\tfeat/x\t🟢 0s\n/home/u/beta\tbeta\t–\t💤 33m'


### PR DESCRIPTION
## 問題

`nix run .#update` が starship 1.26.0 のビルド失敗（aarch64-darwin, cctools ld64 クラッシュ）で止まる。

## 原因

- [nixpkgs#540450](https://github.com/NixOS/nixpkgs/issues/540450): ld64 の libc++ hardening 問題で starship のリンクがクラッシュ。Hydra でも失敗しておりバイナリキャッシュが存在しない
- 修正 [nixpkgs#540463](https://github.com/NixOS/nixpkgs/pull/540463) は 2026-07-11 に master へマージ済みだが、nixos-unstable channel は 2026-07-08 の rev のままで未到達
- 構造的原因: update スクリプトが毎回 `nix flake update` で nixos-unstable の先頭に飛ぶが、channel は darwin 全パッケージのビルド成功を保証しないため、定期的に壊れた rev を踏む

## 変更内容

1. **starship overlay**（即時修正）: upstream fix と同内容の `-fuse-ld=lld` リンク回避を overlay で先取り。既存の direnv/mise/ollama overlay と同じ「nixpkgs 側で直ったら削除可」パターン。channel に nixpkgs#540463 が到達したら削除可
2. **update / update-all の自動ロールバック**（根本対策）: `nix flake update` 後に `nix build --no-link` でビルド検証し、失敗時は flake.lock を更新前に自動ロールバックして既知の正常入力のまま switch を継続
3. flake.lock を失敗した update と同じ入力（nixpkgs 0bb7ec54 / home-manager 0992a29）に更新

## 検証

- overlay 適用を壊れた nixpkgs rev 上で eval 検証: `nativeBuildInputs` に lld-21.1.8、`NIX_CFLAGS_LINK=-fuse-ld=lld` を確認
- update / update-all スクリプト: bash 構文チェック OK、flake eval OK、`nix fmt` 適用済み
- ⚠️ 実ビルドはセッションの sandbox が nix daemon socket をブロックするため未実施。マージ前に手元で `nix build --no-link '.#homeConfigurations.naramotoyuuji-darwin.pkgs.starship'` の確認を推奨