### PR TITLE
feat(claude-code): stop-devflow-telemetry hook に ci_wait_seconds / ci_poll_attempts パススルーを追加

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -66,6 +66,8 @@ for f in "${PENDING_DIR}"/*.json; do
   eval_staleness=""
   repo=""
   pr_number=""
+  ci_wait_seconds=""
+  ci_poll_attempts=""
 
   if ! parsed=$(jq -e '{
     skill: .skill,
@@ -83,7 +85,9 @@ for f in "${PENDING_DIR}"/*.json; do
     eval_iter: .telemetry.eval_iter,
     eval_verdict: .telemetry.eval_verdict,
     iterate_status: .telemetry.iterate_status,
-    eval_staleness: .telemetry.eval_staleness
+    eval_staleness: .telemetry.eval_staleness,
+    ci_wait_seconds: .telemetry.ci_wait_seconds,
+    ci_poll_attempts: .telemetry.ci_poll_attempts
   }' "$claimed" 2>/dev/null); then
     # JSON parse error
     mkdir -p "${PENDING_DIR}/malformed"
@@ -119,6 +123,8 @@ for f in "${PENDING_DIR}"/*.json; do
   eval_staleness=$(echo "$parsed" | jq -r '.eval_staleness // empty')
   repo=$(echo "$parsed" | jq -r '.repo // empty')
   pr_number=$(echo "$parsed" | jq -r '.pr_number // empty')
+  ci_wait_seconds=$(echo "$parsed" | jq -r '.ci_wait_seconds // empty')
+  ci_poll_attempts=$(echo "$parsed" | jq -r '.ci_poll_attempts // empty')
 
   # --- Resolve journal.sh ---
   journal_sh=""
@@ -161,6 +167,12 @@ for f in "${PENDING_DIR}"/*.json; do
   fi
   if [[ -n $pr_number && $pr_number != "null" ]]; then
     cmd_args+=(--pr-number "$pr_number")
+  fi
+  if [[ -n $ci_wait_seconds && $ci_wait_seconds != "null" ]]; then
+    cmd_args+=(--ci-wait-seconds "$ci_wait_seconds")
+  fi
+  if [[ -n $ci_poll_attempts && $ci_poll_attempts != "null" ]]; then
+    cmd_args+=(--ci-poll-attempts "$ci_poll_attempts")
   fi
 
   # --- Execute journal.sh ---

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -260,7 +260,9 @@ STUB_EOF
         eval_iter: 3,
         eval_verdict: "PASS",
         iterate_status: "converged",
-        eval_staleness: "iterate_fixed"
+        eval_staleness: "iterate_fixed",
+        ci_wait_seconds: 30,
+        ci_poll_attempts: 3
       }
     }' >"${tmpd}/journal/pending/handoff.json"
 
@@ -303,6 +305,16 @@ STUB_EOF
       pass "optional_pr_number_present"
     else
       fail "optional_pr_number_present" "--pr-number 123 not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--ci-wait-seconds 30"; then
+      pass "optional_ci_wait_seconds_present"
+    else
+      fail "optional_ci_wait_seconds_present" "--ci-wait-seconds 30 not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--ci-poll-attempts 3"; then
+      pass "optional_ci_poll_attempts_present"
+    else
+      fail "optional_ci_poll_attempts_present" "--ci-poll-attempts 3 not found. got: ${captured}"
     fi
   else
     fail "optional_fields_stub_called" "capture file not created"
@@ -367,6 +379,16 @@ STUB_EOF
       pass "no_pr_number_when_absent"
     else
       fail "no_pr_number_when_absent" "--pr-number should not appear"
+    fi
+    if ! echo "$captured" | grep -q -- "--ci-wait-seconds"; then
+      pass "no_ci_wait_seconds_when_absent"
+    else
+      fail "no_ci_wait_seconds_when_absent" "--ci-wait-seconds should not appear"
+    fi
+    if ! echo "$captured" | grep -q -- "--ci-poll-attempts"; then
+      pass "no_ci_poll_attempts_when_absent"
+    else
+      fail "no_ci_poll_attempts_when_absent" "--ci-poll-attempts should not appear"
     fi
   else
     fail "no_optional_fields_stub_called" "capture file not created"


### PR DESCRIPTION
## 概要

skills PR https://github.com/it-all-playpark/skills/pull/335 のレビュー指摘対応。

`pr-iterate.js` は telemetry handoff JSON に `telemetry.ci_wait_seconds` /
`telemetry.ci_poll_attempts` を書き込むが、flush 側の Stop hook
`stop-devflow-telemetry.sh` はこれまで抽出するキーを明示列挙しており（`merge_tier` /
`iterate_status` / `eval_staleness` 等のみ）、この2キーをマップしていなかった。
`journal.sh` 側には `--ci-wait-seconds` / `--ci-poll-attempts` フラグが既に存在するが
呼び出し元が無く dead code になっていた。

過去の #67（skills#309、repo/pr_number パススルー）と同じパターンで、
`telemetry.ci_wait_seconds` / `telemetry.ci_poll_attempts` を `journal.sh` の
`--ci-wait-seconds` / `--ci-poll-attempts` へ透過する。

## 変更内容

- `stop-devflow-telemetry.sh`: `ci_wait_seconds` / `ci_poll_attempts` を jq で抽出し、
  非 null/非空のときのみ `--ci-wait-seconds` / `--ci-poll-attempts` を `cmd_args` に追加
  （既存の `repo` / `pr_number` と同型）
- `stop-devflow-telemetry.test.sh`: optional fields 有無の既存テストケース
  （Test 5 / Test 6）に `ci_wait_seconds` / `ci_poll_attempts` の有無検証を追加

## テスト計画

- [x] `bash claude-code/hooks/stop-devflow-telemetry.test.sh` — 34 tests pass