### PR TITLE
✨ feat: feat: hunk (review-first diff viewer) を home-manager 環境に導入 (#89)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,48 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "hunk",
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -17,6 +60,42 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "hunk": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783931038,
+        "narHash": "sha256-gKf9U1sjnmR2Ok7lGAO5qqYsJ7ZWcP41jGqhcMzFQLk=",
+        "owner": "modem-dev",
+        "repo": "hunk",
+        "rev": "4fdf4bc1e26f6fdceeced81bf7bae8f9bcb8588a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "modem-dev",
+        "repo": "hunk",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
         "type": "github"
       }
     },
@@ -56,15 +135,68 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "hunk": "hunk",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hunk",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # hunk - review-first diff viewer (https://github.com/modem-dev/hunk)
+    hunk = {
+      url = "github:modem-dev/hunk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -29,6 +34,7 @@
       home-manager,
       nix-darwin,
       treefmt-nix,
+      hunk,
       ...
     }:
     let
@@ -85,6 +91,9 @@
                     old.preBuild;
               });
             })
+            # hunk は flake input から取得（nixpkgs unstable 未着のため overlay で pkgs.hunk を注入。
+            # nixpkgs に hunk が降りてきた場合もこの overlay が優先される）
+            (_final: _prev: { hunk = hunk.packages.${system}.default; })
           ];
         }
       );

--- a/lib/cli-packages.nix
+++ b/lib/cli-packages.nix
@@ -52,6 +52,7 @@ let
     fastfetch
     ffmpeg
     flyctl
+    hunk
     mariadb
     marp-cli
     ollama

--- a/tests/cli-packages.test.sh
+++ b/tests/cli-packages.test.sh
@@ -37,7 +37,10 @@ eval_pkg_names() {
   nix eval --json --impure --expr "
     let
       flake = builtins.getFlake \"${REPO_ROOT}\";
-      pkgs = flake.inputs.nixpkgs.legacyPackages.${system};
+      pkgs = import flake.inputs.nixpkgs {
+        system = \"${system}\";
+        overlays = [ (_final: _prev: { hunk = flake.inputs.hunk.packages.\"${system}\".default; }) ];
+      };
     in
       map (p: p.pname or p.name) (
         import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; mode = \"${mode}\"; }
@@ -69,6 +72,30 @@ if echo "${host_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length == 0'
 else
   fail "hostMode_unchanged_no_nodejs_in_cli_packages" \
     "nodejs must NOT appear in host mode (managed by mise). Got: ${host_pkgs}"
+fi
+
+# ---------------------------------------------------------------------------
+# AC: host mode must include hunk (git diff review TUI)
+# upstream pname is "hunkdiff" (binary is bin/hunk), so use a prefix match.
+# ---------------------------------------------------------------------------
+echo "- hostMode_includes_hunk"
+if echo "${host_pkgs}" | jq -e 'map(select(startswith("hunk"))) | length > 0' >/dev/null 2>&1; then
+  pass "hostMode_includes_hunk"
+else
+  fail "hostMode_includes_hunk" \
+    "Expected hunk* in host mode packages, got: ${host_pkgs}"
+fi
+
+# ---------------------------------------------------------------------------
+# AC: container mode must NOT include hunk (host-only, not needed in
+# hermes-agent container image)
+# ---------------------------------------------------------------------------
+echo "- containerMode_excludes_hunk"
+if echo "${container_pkgs}" | jq -e 'map(select(startswith("hunk"))) | length == 0' >/dev/null 2>&1; then
+  pass "containerMode_excludes_hunk"
+else
+  fail "containerMode_excludes_hunk" \
+    "hunk must NOT appear in container mode (host-only tool). Got: ${container_pkgs}"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要
Closes #89

AI エージェントが生成する複数ファイルにまたがる changeset を効率的にレビューできるよう、review-first な TUI diff ビューア [hunk](https://github.com/modem-dev/hunk) を home-manager 環境（host mode）に導入する。

## 動機
現状の diff レビューは delta（pager）のみで、エージェント作業中の working tree を追従表示したり、複数ファイル間をナビゲーションしながらレビューする手段がない。hunk はサイドバー付きマルチファイルレビューと watch mode（working tree 自動リロード）を提供し、この用途に特化している。

delta は `git diff` / `git add -p` の pager 用途で引き続き使用し、置き換えは行わない。

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `flake.nix` | flake input に `hunk`（`github:modem-dev/hunk`, `inputs.nixpkgs.follows = "nixpkgs"`）を追加。nixpkgs 未収載のため overlay で `pkgs.hunk = hunk.packages.${system}.default` を注入 |
| `lib/cli-packages.nix` | host mode の CLI パッケージ一覧に `hunk` を追加（container mode には追加しない） |
| `tests/cli-packages.test.sh` | overlay 適用済み `pkgs` を使うようテスト内 nix eval を更新し、host mode で `hunk` が含まれること／container mode で含まれないことを検証するケースを追加 |
| `flake.lock` | `hunk` input 追加に伴う lock 更新 |

## テスト計画
- [x] `tests/cli-packages.test.sh` に host/container 双方の AC を追加
- [ ] `nix flake check` 通過確認（CI）
- [ ] `nix run .#update` 適用後の `hunk --version` / `hunk diff` 動作確認（適用環境での手動確認）