### PR TITLE
fix(nix): hunk の nixpkgs を 26.05-darwin に固定（x86_64-darwin eval error 修正）

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,9 +66,7 @@
     "hunk": {
       "inputs": {
         "bun2nix": "bun2nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1783931038,
@@ -121,16 +119,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1783868237,
+        "narHash": "sha256-MDQLbs882ugMi408mpSwa2nw2yzN43hHtOxx0zbUcZA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "76fe02659c00bef75e12fbfdd45ca665115e9302",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -150,12 +148,28 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "hunk": "hunk",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # hunk - review-first diff viewer (https://github.com/modem-dev/hunk)
+    # nixpkgs を follows しない: hunk → bun2nix (flake-parts) が x86_64-darwin を含む
+    # 全システム向けに outputs を評価するため、x86_64-darwin サポートを打ち切った
+    # nixos-unstable を follows すると aarch64-darwin でも eval error になる。
+    # x86_64-darwin を保持する stable branch に固定する（branch 指定なので
+    # nix flake update でも branch 内更新に留まり再発しない）。
+    # hunk が nixos-unstable channel に着弾したら input ごと削除して pkgs.hunk に切替可。
     hunk = {
       url = "github:modem-dev/hunk";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     };
   };
 
@@ -39,10 +45,11 @@
     }:
     let
       # サポートするシステムのリスト
+      # x86_64-darwin (Intel Mac) は使用予定がなく、nixpkgs unstable (26.11) が
+      # サポートを打ち切ったため対象外。
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,13 @@
     # 全システム向けに outputs を評価するため、x86_64-darwin サポートを打ち切った
     # nixos-unstable を follows すると aarch64-darwin でも eval error になる。
     # x86_64-darwin を保持する stable branch に固定する（branch 指定なので
-    # nix flake update でも branch 内更新に留まり再発しない）。
-    # hunk が nixos-unstable channel に着弾したら input ごと削除して pkgs.hunk に切替可。
+    # nix flake update でも branch 内更新に留まり、26.11 の打ち切りエラーは再発しない）。
+    # 注意: Linux (WSL) 構成の hunk もこの pin でビルドされる（cli-packages.nix の
+    # hostOnly に platform gate なしで含まれるため）。darwin 系 branch の rev は
+    # Linux 向け binary cache と一致しない場合があり source build に落ち得る。
+    # nixpkgs-26.05-darwin は 2026 年末に EOL。それまでに hunk が nixos-unstable
+    # channel に着弾したら input ごと削除して pkgs.hunk に切替する
+    # （着弾すると overlay の warnIf が eval warning で通知する）。
     hunk = {
       url = "github:modem-dev/hunk";
       inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
@@ -99,8 +104,14 @@
               });
             })
             # hunk は flake input から取得（nixpkgs unstable 未着のため overlay で pkgs.hunk を注入。
-            # nixpkgs に hunk が降りてきた場合もこの overlay が優先される）
-            (_final: _prev: { hunk = hunk.packages.${system}.default; })
+            # nixpkgs に hunk が降りてきた場合もこの overlay が優先されるが、
+            # warnIf が eval warning で「input 削除して pkgs.hunk へ切替可」と通知する）
+            (_final: prev: {
+              hunk =
+                nixpkgs.lib.warnIf (prev ? hunk)
+                  "hunk が nixpkgs に着弾済み: flake input 'hunk' とこの overlay を削除して pkgs.hunk に切替可"
+                  hunk.packages.${system}.default;
+            })
             # starship 1.26.0 は darwin で cctools ld64 がクラッシュしビルド失敗する
             # (nixpkgs#540450, ld64 の libc++ hardening 問題)。
             # upstream fix (nixpkgs#540463) と同じく lld でリンクして回避。


### PR DESCRIPTION
## 問題

`nix run .#update` が以下のエラーで失敗する:

> error: Nixpkgs 26.11 has dropped support for x86_64-darwin.

マシンは aarch64-darwin だが、`hunk` → `bun2nix`（flake-parts + treefmt-nix）が
x86_64-darwin を含む全システム向けに flake outputs（`perSystem.x86_64-darwin.formatter`）を
評価するため、`inputs.nixpkgs.follows = "nixpkgs"`（nixos-unstable）経由で
サポート打ち切り済みの nixpkgs が x86_64-darwin 向けに import され eval error になっていた。
7/8・7/11 両 rev が打ち切り後のため、update script の rollback でも回復しない。

## 修正

- `hunk` input の `nixpkgs.follows` を外し、x86_64-darwin を保持する
  `nixpkgs-26.05-darwin` branch に固定
  - 単純な follows 削除では hunk 自前 lock ではなく最新 nixos-unstable（壊れた rev）で
    re-lock されるため、branch への明示固定が必要（実測で確認）
  - branch 指定なので `nix flake update` でも branch 内更新に留まる
  - 26.05 は 2026 年末まで security fix が提供される
- Intel Mac は今後使用しないため `supportedSystems` から `x86_64-darwin` を削除
  （これ単体では bun2nix 側の eval は防げないので上記と併用）

## Linux (WSL) 構成への波及（code review 指摘）

`hunk` は `lib/cli-packages.nix` の hostOnly に platform gate なしで含まれるため、
`linux-x86` / `linux-arm` の home 構成も 26.05-darwin pin 由来の hunk をビルドする。

- darwin 系 branch の rev は Linux 向け binary cache の jobset と一致しない場合があり、
  hunk の依存 closure が source build に落ちてビルドが長時間化し得る（壊れはしない）
- `verify_or_rollback` は実行マシンの構成しか検証しないため、Mac での update は
  Linux 構成を未検証のまま lock を進める（従来からの挙動だが、この pin で影響範囲が広がる）

## 恒久対応の仕組み（code review 指摘）

hunk は nixpkgs master に着弾済み（`pkgs/by-name/hu/hunk`）。overlay に `lib.warnIf` を
追加し、**hunk が root nixpkgs (nixos-unstable) に着弾した時点で eval warning が出て
input 削除・`pkgs.hunk` 切替を促す**ようにした（コメント上の計画を人間の記憶頼みにしない）。
`nixpkgs-26.05-darwin` の EOL（2026 年末）もコメントに明記。

## 検証

daemonless local store で eval を確認（エラーは eval 時のものなので instantiation 成功 = 修正確認）:

- `homeConfigurations.naramotoyuuji-darwin.activationPackage.drvPath` ✅
- `homeConfigurations.yuji_naramoto-darwin.activationPackage.drvPath` ✅
- `darwinConfigurations.MyMBP-naramotoyuuji.system.drvPath` ✅
- warnIf 追加後も同一 drv hash（eval 層のみの変更）・警告の誤発火なし ✅

merge 後は `nix run .#update naramotoyuuji` で switch まで通ることを実機確認してください。