### PR TITLE
feat(herdr): default shell を fish に設定

### DIFF
--- a/home-manager/home/file/herdr/config.toml
+++ b/home-manager/home/file/herdr/config.toml
@@ -9,6 +9,11 @@
 # - copy mode 内の大西移動キー → herdr copy mode は h/j/k/l 固定
 # - Alt+b BreakPane (pane の新タブ昇格) → 対応 action なし
 
+[terminal]
+# 新規 pane の shell — zellij config.kdl の default_shell "fish" と同じ。
+# 未設定だと $SHELL (login shell = /bin/zsh) が使われ、pane 分割で zsh が起動する。
+default_shell = "fish"
+
 [keys]
 # prefix — tmux/zellij (Ctrl+a) と同じ (herdr default: ctrl+b)
 prefix = "ctrl+a"

--- a/tests/herdr-config.test.sh
+++ b/tests/herdr-config.test.sh
@@ -141,6 +141,19 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# tier-1 (5c): [terminal] default_shell = "fish" (zellij config.kdl と同じ)
+# ---------------------------------------------------------------------------
+echo "- configToml_sets_default_shell_fish"
+if [ -f "${CONFIG_TOML}" ] &&
+  awk '/^\[terminal\]/{f=1;next} /^\[/{f=0} f' "${CONFIG_TOML}" |
+  grep -qE '^default_shell *= *"fish"'; then
+  pass "configToml_sets_default_shell_fish"
+else
+  fail "configToml_sets_default_shell_fish" \
+    "Expected default_shell = \"fish\" inside [terminal] section in ${CONFIG_TOML}"
+fi
+
+# ---------------------------------------------------------------------------
 # tier-1 (6): reload_config must NOT be overridden (keep herdr default prefix+shift+r)
 # ---------------------------------------------------------------------------
 echo "- configToml_does_not_set_reload_config"


### PR DESCRIPTION
## 概要
herdr で pane 分割すると zsh の pane が開く問題の修正。herdr は `default_shell` 未設定だと `$SHELL`（login shell = `/bin/zsh`）を使うため、`[terminal] default_shell = "fish"` を追加して zellij（`config.kdl` の `default_shell "fish"`）と挙動を揃える。

## 変更内容
- `home-manager/home/file/herdr/config.toml`: `[terminal]` セクションを追加し `default_shell = "fish"` を設定
- `tests/herdr-config.test.sh`: tier-1 (5c) `configToml_sets_default_shell_fish` を追加

## テスト
- `bash tests/herdr-config.test.sh` → tier-1: 9 passed, 0 failed（tier-2 は sandbox のため SKIP）

## 適用手順
1. merge 後 `home-manager switch`（または通常の apply フロー）
2. `herdr server reload-config` で稼働中セッションに反映