### PR TITLE
🐛 fix(herdr): Alt+w を goto (session navigator) に変更 + tier-2 テスト堅牢化

### DIFF
--- a/home-manager/home/file/herdr/config.toml
+++ b/home-manager/home/file/herdr/config.toml
@@ -51,8 +51,10 @@ switch_tab = "alt+1..9"
 copy_mode = ["alt+i", "prefix+["]
 
 # session/workspace 操作 — zellij の Alt+d (Detach) / Alt+w (session-manager)
+# goto = session navigator (全 workspace/pane 横断の検索付き floating overlay) が
+# zellij session-manager に最も近い。workspace_picker は sidebar 選択面なので使わない。
 detach = ["alt+d", "prefix+q"]
-workspace_picker = ["alt+w", "prefix+w"]
+goto = ["alt+w", "prefix+g"]
 
 # resize mode — zellij の Ctrl+Alt 系 resize の代替入口。
 # default "prefix+r" が focus_pane_up と衝突するため退避し、direct chord も追加。

--- a/tests/cli-packages.test.sh
+++ b/tests/cli-packages.test.sh
@@ -82,7 +82,7 @@ echo "--- tier-2: nix eval verification (requires nix daemon) ---"
 eval_pkg_names() {
   local mode="$1"
   local system
-  system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+  system="$(nix eval --impure --raw --expr 'builtins.currentSystem' 2>/dev/null || true)"
   nix eval --json --impure --expr "
     let
       flake = builtins.getFlake \"${REPO_ROOT}\";
@@ -97,7 +97,7 @@ eval_pkg_names() {
   " 2>/dev/null
 }
 
-if nix store info >/dev/null 2>&1; then
+if nix store info >/dev/null 2>&1 && nix eval --impure --raw --expr 'builtins.currentSystem' >/dev/null 2>&1; then
   NIX_AVAILABLE=1
 else
   NIX_AVAILABLE=0
@@ -108,7 +108,7 @@ if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # AC1: container mode must include nodejs_24
   # -------------------------------------------------------------------------
   echo "- eval_containerMode_includes_nodejs_24"
-  container_pkgs="$(eval_pkg_names "container")"
+  container_pkgs="$(eval_pkg_names "container" || true)"
   if echo "${container_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length > 0' >/dev/null 2>&1; then
     pass "eval_containerMode_includes_nodejs_24"
   else
@@ -120,7 +120,7 @@ if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # AC1 supplement: host mode must NOT include nodejs (PATH collision guard)
   # -------------------------------------------------------------------------
   echo "- eval_hostMode_unchanged_no_nodejs_in_cli_packages"
-  host_pkgs="$(eval_pkg_names "host")"
+  host_pkgs="$(eval_pkg_names "host" || true)"
   if echo "${host_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length == 0' >/dev/null 2>&1; then
     pass "eval_hostMode_unchanged_no_nodejs_in_cli_packages"
   else

--- a/tests/herdr-config.test.sh
+++ b/tests/herdr-config.test.sh
@@ -195,7 +195,7 @@ echo "--- tier-2: nix eval verification (requires nix daemon) ---"
 eval_pkg_names() {
   local mode="$1"
   local system
-  system="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+  system="$(nix eval --impure --raw --expr 'builtins.currentSystem' 2>/dev/null || true)"
   nix eval --json --impure --expr "
     let
       flake = builtins.getFlake \"${REPO_ROOT}\";
@@ -207,7 +207,7 @@ eval_pkg_names() {
   " 2>/dev/null
 }
 
-if nix store info >/dev/null 2>&1; then
+if nix store info >/dev/null 2>&1 && nix eval --impure --raw --expr 'builtins.currentSystem' >/dev/null 2>&1; then
   NIX_AVAILABLE=1
 else
   NIX_AVAILABLE=0
@@ -218,7 +218,7 @@ if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # tier-2 (a): host mode must include herdr
   # -------------------------------------------------------------------------
   echo "- eval_hostMode_includes_herdr"
-  host_pkgs="$(eval_pkg_names "host")"
+  host_pkgs="$(eval_pkg_names "host" || true)"
   if echo "${host_pkgs}" | jq -e 'map(select(. == "herdr")) | length > 0' >/dev/null 2>&1; then
     pass "eval_hostMode_includes_herdr"
   else
@@ -230,7 +230,7 @@ if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # tier-2 (b): container mode must NOT include herdr (hostOnly, not needed in image)
   # -------------------------------------------------------------------------
   echo "- eval_containerMode_excludes_herdr"
-  container_pkgs="$(eval_pkg_names "container")"
+  container_pkgs="$(eval_pkg_names "container" || true)"
   if echo "${container_pkgs}" | jq -e 'map(select(. == "herdr")) | length == 0' >/dev/null 2>&1; then
     pass "eval_containerMode_excludes_herdr"
   else

--- a/tests/herdr-config.test.sh
+++ b/tests/herdr-config.test.sh
@@ -129,7 +129,7 @@ if [ -f "${CONFIG_TOML}" ] &&
   grep -Fq 'switch_tab = "alt+1..9"' "${CONFIG_TOML}" &&
   grep -qE 'copy_mode *= *\["alt\+i", *"prefix\+\["\]' "${CONFIG_TOML}" &&
   grep -qE 'detach *= *\["alt\+d", *"prefix\+q"\]' "${CONFIG_TOML}" &&
-  grep -qE 'workspace_picker *= *\["alt\+w", *"prefix\+w"\]' "${CONFIG_TOML}" &&
+  grep -qE 'goto *= *\["alt\+w", *"prefix\+g"\]' "${CONFIG_TOML}" &&
   grep -qE 'navigate_pane_left *= *"t"' "${CONFIG_TOML}" &&
   grep -qE 'navigate_pane_down *= *"n"' "${CONFIG_TOML}" &&
   grep -qE 'navigate_pane_up *= *"r"' "${CONFIG_TOML}" &&
@@ -137,7 +137,7 @@ if [ -f "${CONFIG_TOML}" ] &&
   pass "configToml_has_zellij_ported_bindings"
 else
   fail "configToml_has_zellij_ported_bindings" \
-    "Expected zellij-ported bindings (prefix=ctrl+a, split_*, close_pane, zoom, tab ops, switch_tab, copy_mode, detach, workspace_picker, navigate_pane_* 大西配列) in ${CONFIG_TOML}"
+    "Expected zellij-ported bindings (prefix=ctrl+a, split_*, close_pane, zoom, tab ops, switch_tab, copy_mode, detach, goto, navigate_pane_* 大西配列) in ${CONFIG_TOML}"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

PR #95 のフォローアップ 2 件。

### 1. Alt+w の binding 先を workspace_picker → goto に変更

zellij の session-manager (検索付き floating list で session 切替) に最も近いのは:

- ❌ `workspace_picker` — sidebar の workspace 選択面 (navigate mode) に入るだけで検索 UI なし
- ✅ `goto` = session navigator — 全 workspace/pane 横断の検索付き floating overlay (`src/ui/navigator.rs` で検索ボックス + 全 pane 一覧 + jump を裏取り)

`goto = ["alt+w", "prefix+g"]` に変更し、workspace_picker は herdr default (`prefix+w`) のまま。

### 2. tier-2 テストの set -e 即死を修正

sandbox から nix daemon への到達性が不安定な環境で、`nix store info` は成功するが `nix eval` が失敗すると、command substitution の失敗が `set -e` でテスト全体を summary 無しで即死させていた (main にも存在するバグ)。

- `eval_pkg_names` 呼び出しに `|| true` を追加 (eval 失敗は FAIL として報告)
- `NIX_AVAILABLE` 判定に trivial eval probe を追加 (中途半端な到達状態は SKIP)

## テスト

- `tests/herdr-config.test.sh`: 9 passed, 0 failed (tier-2 は sandbox で SKIP) — 3 回連続実行で安定
- `tests/cli-packages.test.sh`: 2 passed, 0 failed — 同上
- shfmt / shellcheck clean

## 補足

- merge 後に残った stale branch `feature/issue-90` (goto 修正の push で誤って再作成) は削除してください
- tier-2 完全検証は sandbox 外で `bash tests/herdr-config.test.sh` を推奨