### PR TITLE
feat(home): hunk 同梱スキル hunk-review を ~/.claude/skills に symlink

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -107,6 +107,23 @@ in
         echo "Warning: $SKILLS_AGENTS does not exist. Skipping agents symlink."
       fi
 
+      # ~/.claude/skills/hunk-review → hunk 同梱スキル（upstream 推奨の symlink 方式）
+      # `hunk skill path` の store path は hunk 更新 + GC で消えるため、
+      # rebuild ごとに現行世代の pkgs.hunk へ貼り直して同期を保つ。
+      # ~/.claude/skills は skills repo への symlink なので実体は repo 内に作られる
+      # （store path は環境依存のため skills repo 側で gitignore する）。
+      CLAUDE_SKILLS="$CLAUDE_DIR/skills"
+      HUNK_SKILL="$CLAUDE_SKILLS/hunk-review"
+      if [ -d "$CLAUDE_SKILLS" ]; then
+        if [ -L "$HUNK_SKILL" ] || [ ! -e "$HUNK_SKILL" ]; then
+          ln -sfn "${pkgs.hunk}/skills/hunk-review" "$HUNK_SKILL"
+        else
+          echo "Warning: $HUNK_SKILL exists and is not a symlink. Skipping (manual review needed)."
+        fi
+      else
+        echo "Warning: $CLAUDE_SKILLS does not exist. Skipping hunk-review skill symlink."
+      fi
+
       # settings.json へのシンボリックリンク
       # 既存ファイルがシンボリックリンクでない場合は削除
       if [ -f "$CLAUDE_DIR/settings.json" ] && [ ! -L "$CLAUDE_DIR/settings.json" ]; then


### PR DESCRIPTION
## 概要

hunk (modem-dev/hunk) が同梱する Claude Code 用スキル `hunk-review` を、upstream 推奨の symlink 方式で `~/.claude/skills/hunk-review` に常設する。

## 背景

- `hunk skill --help` 公式文言: "Load or symlink that file in your coding agent to keep it in sync across Hunk upgrades."
- `hunk skill path` が返す nix store path は hunk 更新 + GC でリンク切れするため、home-manager activation で rebuild ごとに現行世代の `${pkgs.hunk}/skills/hunk-review` へ貼り直す。

## 変更内容

- `home-manager/home/default.nix`: `activation.setupClaudeCode` に hunk-review symlink 処理を追加（既存の agents symlink と同パターン: 非 symlink の既存物があれば warning でスキップ）

## 補足

- `~/.claude/skills` は skills repo への symlink のため、リンク実体は skills repo 内に作られる。skills repo 側 `.gitignore` に `hunk-review` を追加済み（別リポジトリのため本 PR 外、未コミット）
- 検証: `nix fmt`（差分なし）、`nix-instantiate --parse` OK。sandbox 制約で nix daemon に接続できずローカル full eval は未実施 → CI の `nix flake check` で確認