### PR TITLE
feat(darwin): moshi-hook を Homebrew 宣言管理に追加

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -58,6 +58,17 @@ in
       cleanup = "uninstall"; # Brewfileにないものをアンインストール
       extraFlags = [ "--force-cleanup" ]; # cleanup実行時の確認を明示的に許可
     };
+    taps = [
+      "rjyo/moshi" # moshi-hook 配布用 tap
+    ];
+    brews = [
+      {
+        # コーディングエージェント(Claude Code等)のイベントを iOS アプリ Moshi に中継する常駐デーモン
+        name = "moshi-hook";
+        start_service = true;
+        restart_service = "changed";
+      }
+    ];
     casks = [
       # インストールするCaskアプリケーションのリスト
       "antigravity"


### PR DESCRIPTION
## 概要
iOS ターミナルアプリ Moshi の companion デーモン **moshi-hook** を nix-darwin の Homebrew 宣言管理に追加する。

## 変更内容
- `homebrew.taps` に `rjyo/moshi` を追加
- `homebrew.brews` に `moshi-hook` を追加（`start_service = true` / `restart_service = "changed"` で brew services 常駐）

## 背景
- Claude Code 等のエージェントイベント（承認待ち・完了・ツールエラー）を iPhone の Moshi アプリに中継し、Live Activity / Apple Watch からのリモート承認を可能にする
- `onActivation.cleanup = "uninstall"` 運用のため、手動 `brew install` では次回 activation で削除される → 宣言管理が必須

## 検証
- `nix-instantiate --parse` で構文チェック済み
- sandbox 制約（nix daemon socket 不可）のためフル eval は未実施。**マージ前に `nix run .#update` での適用確認を推奨**

## 適用後の確認
```bash
brew services list | grep moshi-hook   # started になっていること
```
Moshi 側の hooks 自動設定が `~/.claude/settings.json` を書き換える可能性があるため、適用後に dotfiles 管理の設定と diff がないか確認してください。