### PR TITLE
feat(mise): claude-code/codex/copilot を minimum_release_age から除外し即日追随

### DIFF
--- a/home-manager/home/file/mise/config.toml
+++ b/home-manager/home/file/mise/config.toml
@@ -29,3 +29,6 @@ java = "21"
 
 [settings]
 experimental = true
+# 供給網攻撃対策の minimum_release_age (default: 24h) から除外し、リリース即日で追随する。
+# いずれも GitHub Releases (aqua) 直取得のためリスク低。npm:* 系は 24h ガードを維持する。
+minimum_release_age_excludes = ["claude-code", "codex", "copilot"]


### PR DESCRIPTION
## 概要

mise はデフォルトで `minimum_release_age = 24h` の supply-chain ガードを持つため、`latest` 指定でもリリースから 24 時間は新バージョンに追随できない。ほぼ毎日リリースされる claude-code / codex / copilot を `minimum_release_age_excludes` に指定し、即日追随を可能にする。

これまで手動で `MISE_MINIMUM_RELEASE_AGE=0 mise upgrade` としていた運用を宣言的に置き換える（env var は全ツールのガードを外すため、除外リスト方式の方が安全）。

## 変更内容

- `home-manager/home/file/mise/config.toml` の `[settings]` に `minimum_release_age_excludes = ["claude-code", "codex", "copilot"]` を追加

## 安全性

- 3 ツールとも aqua backend（GitHub Releases 直取得: anthropics / openai / github org）でリスクは低い
- `npm:*` 系ツール（vercel, wrangler, tsx 等）は 24h ガードを維持

## 検証

- `MISE_GLOBAL_CONFIG_FILE=<worktree>/.../config.toml mise settings get minimum_release_age_excludes` → `["claude-code", "codex", "copilot"]` が返ることを確認済み

適用は merge 後に `nix run .#update`。