### PR TITLE
feat(launchd): mise upgrade を日次自動実行する launchd agent を追加

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -468,7 +468,7 @@ in
     # mise 管理ツールを毎日自動更新する。
     # minimum_release_age_excludes (mise/config.toml) と組で、claude-code 等の
     # 高頻度リリースツールへの即日追随を宣言的に実現する。
-    # 09:00 にスリープ中だった場合は launchd が復帰時にまとめて実行する。
+    # 04:30 (ローカルタイム) にスリープ中だった場合は launchd が復帰時にまとめて実行する。
     mise-upgrade = {
       enable = true;
       config = {
@@ -488,8 +488,8 @@ in
         };
         StartCalendarInterval = [
           {
-            Hour = 9;
-            Minute = 0;
+            Hour = 4;
+            Minute = 30;
           }
         ];
         RunAtLoad = false;

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -464,5 +464,39 @@ in
         ThrottleInterval = 30;
       };
     };
+
+    # mise 管理ツールを毎日自動更新する。
+    # minimum_release_age_excludes (mise/config.toml) と組で、claude-code 等の
+    # 高頻度リリースツールへの即日追随を宣言的に実現する。
+    # 09:00 にスリープ中だった場合は launchd が復帰時にまとめて実行する。
+    mise-upgrade = {
+      enable = true;
+      config = {
+        Label = "com.playpark.mise-upgrade";
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          ''
+            /bin/wait4path "${pkgs.mise}/bin/mise" \
+              && exec "${pkgs.mise}/bin/mise" upgrade --yes
+          ''
+        ];
+        EnvironmentVariables = {
+          # npm backend が node/npm を解決できるよう mise shims を先頭に置く
+          PATH = "${config.home.homeDirectory}/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+          HOME = config.home.homeDirectory;
+        };
+        StartCalendarInterval = [
+          {
+            Hour = 9;
+            Minute = 0;
+          }
+        ];
+        RunAtLoad = false;
+        ProcessType = "Background";
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/mise-upgrade.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/mise-upgrade.log";
+      };
+    };
   };
 }


### PR DESCRIPTION
## 概要

#106 の `minimum_release_age_excludes` 設定と組で、「claude-code 等の高頻度リリースツールに常に追随する」運用を宣言的に完結させる。これまで手動で日次実行していた `MISE_MINIMUM_RELEASE_AGE=0 mise upgrade` を launchd agent に置き換える。

## 変更内容

- `home-manager/home/default.nix` の `launchd.agents` に `mise-upgrade`（`com.playpark.mise-upgrade`）を追加
  - 毎日 04:30（ローカルタイム）に `mise upgrade --yes` を実行（`StartCalendarInterval`）
  - スリープ中に時刻を跨いだ場合は launchd が復帰時にまとめて実行
  - npm backend が node/npm を解決できるよう mise shims を PATH 先頭に配置
  - ログ: `~/Library/Logs/mise-upgrade.log`

## 検証

- `nix-instantiate --parse` で構文チェック OK
- `nix fmt` で差分なし（フォーマット準拠）

## 適用

merge 後 `nix run .#update`。反映確認は `launchctl list | grep mise-upgrade`、手動発火は
`launchctl kickstart gui/$(id -u)/com.playpark.mise-upgrade`。