### PR TITLE
fix(darwin): moshi-hook を完全修飾名にして tap trust の消失を解消

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -64,7 +64,10 @@ in
     brews = [
       {
         # コーディングエージェント(Claude Code等)のイベントを iOS アプリ Moshi に中継する常駐デーモン
-        name = "moshi-hook";
+        # brew の tap trust は完全修飾名の formula にしか効かない (非修飾名だと
+        # trusted: true が無視され、bundle cleanup が trust store を Brewfile 由来で
+        # 全置換するため手動 `brew trust` も activation の度に消される)。
+        name = "rjyo/moshi/moshi-hook";
         start_service = true;
         restart_service = "changed";
       }


### PR DESCRIPTION
## 問題

`nix run .#update` のたびに `brew trust rjyo/moshi` を要求され、手動で trust しても次回 activation で消える。

## 根本原因（brew 6.0.10 のソースで確認）

1. `brew bundle` の cleanup（nix-darwin が `--force-cleanup` で常時実行）は `Homebrew::Trust.replace!` で **trust store (`~/.homebrew/trust.json`) を Brewfile 由来のエントリで全置換**する → 手動 `brew trust` は activation の度に消える（`Library/Homebrew/bundle/subcommand/cleanup.rb:153`）
2. nix-darwin は brew エントリに `trusted: true` を付与しているが、brew の仕様で **trust が効くのは完全修飾名の formula のみ**。非修飾名 `brew "moshi-hook"` では黙って無視される（`Library/Homebrew/bundle/trust.rb`: "unqualified names cannot be trusted"）
3. `tap "rjyo/moshi"` 行にも `trusted: true` が無い

→ Brewfile 由来の trust エントリが空になり、formula 読込時に "Refusing to load formula from untrusted tap" で bundle が失敗する。

## 修正

`homebrew.brews` の name を完全修飾名 `rjyo/moshi/moshi-hook` に変更。これで Brewfile に `brew "rjyo/moshi/moshi-hook", ..., trusted: true` が出力され、bundle installer が formula trust を自ら書き込み・cleanup 後も維持する。以後、手動 `brew trust` は不要。

tap 全体を trust する `taps = [{ name = "rjyo/moshi"; trusted = true; }]` でも解消するが、formula 単位の trust の方が最小権限のためこちらを採用。

## 検証

- `nix-instantiate --parse` / `nix fmt` OK
- 現行生成済み Brewfile（/nix/store）で `trusted: true` オプション出力は確認済み（名前の修飾のみが欠けていた）
- sandbox から nix daemon に接続できないため full eval は未実施 → merge 後の `nix run .#update` が実地検証

## 適用後の確認

```
nix run .#update naramotoyuuji
cat ~/.homebrew/trust.json   # trustedformulae に rjyo/moshi/moshi-hook が入るはず
```