### PR TITLE
feat(darwin): nix store の自動 GC と optimise を有効化

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -123,6 +123,21 @@ in
     trusted-users = [ "@admin" ]; # 管理者ユーザーを信頼
   };
 
+  # Nix store の自動 GC（毎週日曜 5:00、mise upgrade の 04:30 と競合しない時間帯）
+  # --delete-older-than 14d により直近 2 週間の generation は保持し、rollback 可能性を確保
+  nix.gc = {
+    automatic = true;
+    interval = {
+      Weekday = 0;
+      Hour = 5;
+      Minute = 0;
+    };
+    options = "--delete-older-than 14d";
+  };
+
+  # store 内の同一内容ファイルを hardlink 化してディスク使用量を削減
+  nix.optimise.automatic = true;
+
   # Linux builder（macOS 上で linux 用 derivation を build する VM）
   # hermes-agent 用 Docker image (dockerTools.buildLayeredImage) は Linux 専用のため
   # darwin から build するには linux-builder が必須。


### PR DESCRIPTION
## 概要

/nix/store が 27GB まで肥大化しており（disk 使用率 79%）、手動 GC 運用では flake update のたびに単調増加するため、nix-darwin の launchd 統合で自動化する。

## 変更内容

- **`nix.gc.automatic = true`**: 毎週日曜 5:00 に GC を実行
  - mise upgrade（04:30）と競合しない時間帯を選択
  - `--delete-older-than 14d` で直近 2 週間の generation を保持し、rollback 可能性を確保
- **`nix.optimise.automatic = true`**: store 内の同一内容ファイルを hardlink 化してディスク使用量を削減（GC とは独立に 20〜30% 程度の削減が見込める）

## 注意点

- GC 後の初回 build では消えた依存の再ダウンロード/再ビルドが発生し得るが、週 1 回 + 14 日猶予なら実害はほぼ無い想定
- 適用には `nix run .#update` が必要

## 検証

- sandbox 制約により local で `nix fmt` / `nix flake check` が実行できなかったため、CI での format check を確認してください