### PR TITLE
feat: AI agent 向けコンテキスト節約 CLI 追加 + Tool Routing ルール

### DIFF
--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -27,6 +27,19 @@ Conflict: Safety > Scope > Quality > Speed
 - **Inherit ≠ Default-Heavy**: `agent()` は明示しない限りセッションモデル（opus xhigh）を継承する。軽ステージに指定をサボると全部 opus xhigh になる
 - **No Over-Orchestration**: trivial な単発作業は Workflow 化せず直接ツールを叩く。ultracode でも例外でない
 
+## Tool Routing
+🟢 コンテキスト節約と精度向上のため、ファイル全読み・テキスト grep の前に専用 CLI で絞る:
+- **コードベース概観** → `tokei`（言語構成・規模。ファイルを読み始める前にまず全体像）
+- **構造的コード検索・一括リライト** → `ast-grep`（AST 条件のマッチ・codemod。テキスト grep で偽陽性が出る時）
+- **JSON** → `jq` で必要キーのみ抽出。構造が未知なら `gron <file> | rg <keyword>` でパス発見
+- **YAML/TOML/XML** → `yq` で必要部分のみ抽出
+- **CSV/Parquet/巨大 JSON の集計** → `duckdb -c "SELECT ..."`（Read で全読みしない）
+- **PDF/docx/zip/sqlite 内の検索** → `rga`（ripgrep-all）
+- **機械的な文字列置換** → `sd`（sed より事故りにくい）
+- **diff の構造変化判定** → `difft --exit-code`（フォーマットのみの変更か機械判別）
+- **リポジトリ全体のコンテキスト化** → repomix（/repo-export skill）
+- **性能主張の裏取り** → `hyperfine`（体感や推測で速い/遅いを言わない）
+
 ## Organization
 - Follow existing project conventions for naming and directory structure
 - Reports/analyses → `claudedocs/`、Tests → `tests/`、Scripts → `scripts/`

--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -30,13 +30,14 @@ Conflict: Safety > Scope > Quality > Speed
 ## Tool Routing
 🟢 コンテキスト節約と精度向上のため、ファイル全読み・テキスト grep の前に専用 CLI で絞る:
 - **コードベース概観** → `tokei`（言語構成・規模。ファイルを読み始める前にまず全体像）
-- **構造的コード検索・一括リライト** → `ast-grep`（AST 条件のマッチ・codemod。テキスト grep で偽陽性が出る時）
+- **同一コードパターンを3箇所以上書き換える時**（rename・API移行・codemod）→ sed/手編集でなく `ast-grep --pattern … --rewrite …`。コメント・文字列リテラルへの誤爆がなく、全箇所を機械的に網羅できる
+- **grep 結果にコメント・文字列の偽陽性が混ざる検索** → `ast-grep --pattern`（AST ノードのみマッチ）
 - **JSON** → `jq` で必要キーのみ抽出。構造が未知なら `gron <file> | rg <keyword>` でパス発見
 - **YAML/TOML/XML** → `yq` で必要部分のみ抽出
 - **CSV/Parquet/巨大 JSON の集計** → `duckdb -c "SELECT ..."`（Read で全読みしない）
 - **PDF/docx/zip/sqlite 内の検索** → `rga`（ripgrep-all）
 - **機械的な文字列置換** → `sd`（sed より事故りにくい）
-- **diff の構造変化判定** → `difft --exit-code`（フォーマットのみの変更か機械判別）
+- **refactor・フォーマッタ適用後の「挙動不変」確認** → `difft --exit-code old new`（構造変化ゼロ＝フォーマットのみ、を機械判定。目視 diff レビューを省略できる）
 - **リポジトリ全体のコンテキスト化** → repomix（/repo-export skill）
 - **性能主張の裏取り** → `hyperfine`（体感や推測で速い/遅いを言わない）
 

--- a/lib/cli-packages.nix
+++ b/lib/cli-packages.nix
@@ -29,6 +29,7 @@ let
     gh
     ghq
     git
+    gron # JSON を grep 可能な行形式に展開。構造が未知の JSON を全読みせず `gron | rg` で探索できる
     gws
     jq
     lazygit
@@ -40,9 +41,11 @@ let
     starship
     stripe-cli
     tldr
+    tokei # コードベースの言語構成・規模を1コマンドで把握。AI agent が全ファイルを読まずに概観を得る
     turso-cli
     vips
     which
+    yq-go # YAML/TOML/XML から必要部分だけ抽出 (jq の YAML 版)。設定ファイル全読みを避ける
     zellij
     zoxide
   ];
@@ -53,11 +56,13 @@ let
     act
     agent-browser
     dotenv-cli
+    duckdb # CSV/Parquet/巨大 JSON を SQL で集計・抽出。AI agent がデータファイルを全読みせず必要行だけ取り出す
     fastfetch
     ffmpeg
     flyctl
     herdr
     hunk
+    hyperfine # 統計的に妥当なベンチマーク CLI。性能主張を計測で裏付ける (Evidence > assumptions)
     mariadb
     marp-cli
     netlify-cli


### PR DESCRIPTION
## 概要
AI agent がファイル全読み・テキスト grep に頼らず、抽出系 CLI でコンテキストウィンドウの圧迫を低減できるようにする。#111 (ast-grep / difftastic / repomix) の続き。

## 変更内容
### lib/cli-packages.nix
| 追加先 | パッケージ | 用途 |
|---|---|---|
| common | gron | 未知 JSON を `gron \| rg` で構造探索 |
| common | tokei | コードベースの言語構成・規模を1コマンドで概観 |
| common | yq-go | YAML/TOML/XML から必要部分のみ抽出 |
| hostOnly | duckdb | CSV/Parquet/巨大 JSON を SQL で必要行だけ抽出 |
| hostOnly | hyperfine | 性能主張を統計的ベンチマークで裏付け |

### claude-code/RULES.md
- **Tool Routing** セクション新設: 全読みの前に抽出系 CLI（既存の ast-grep / rga / jq / sd / difft / repomix 含む）へ誘導するルーティング指示を集約

## 確認事項
- [x] `nix-instantiate --parse` で構文 OK
- [ ] merge 後 `nix run .#update` で適用
- 注: sandbox 内で treefmt が実行できなかったため、フォーマットは CI の `nix flake check` で確認