### PR TITLE
feat(cli-packages): add bats-core to hostOnly package list

### DIFF
--- a/lib/cli-packages.nix
+++ b/lib/cli-packages.nix
@@ -55,6 +55,7 @@ let
   hostOnly = with pkgs; [
     act
     agent-browser
+    bats # bats-core。skills repo の tests/run-all-bats.sh 等スクリプト隣接テストの実行に必要
     dotenv-cli
     duckdb # CSV/Parquet/巨大 JSON を SQL で集計・抽出。AI agent がデータファイルを全読みせず必要行だけ取り出す
     fastfetch


### PR DESCRIPTION
## Summary
- skills repo の `tests/run-all-bats.sh` はこのマシンに bats-core が未インストールのため graceful skip し続けていた（実機確認済み: `which bats` → not found）
- `lib/cli-packages.nix` の `hostOnly` に `bats` を追加し、`home-manager switch` で全ホストに Nix 管理下配布されるようにした
- Claude 自身は `permissions.deny` の `Bash(brew:*)` によりパッケージインストールを行えない設計のため、`brew install bats-core` の手動実行に代わる恒久対応として Nix 管理に寄せた

## Test plan
- [x] `nix-instantiate --parse lib/cli-packages.nix` — 構文OK
- [x] `bash tests/cli-packages.test.sh` — tier-1 (静的検証) 2/2 pass。tier-2 (nix eval) は sandbox 内で nix daemon 到達不可のため skip（既存の設計通り、sandbox外での実行が必要）
- [ ] `home-manager switch` 適用後、`which bats` で解決されることの確認（sandbox外・実機での確認が必要）