### PR TITLE
✨ hermes claude_runner: per-job コンテナ異常終了時の watchdog/reconcile 実装 (S5, AC-2 NO-GO 対応) (#122)

### DIFF
--- a/claudedocs/hermes-phaseB-execution-model-decision.md
+++ b/claudedocs/hermes-phaseB-execution-model-decision.md
@@ -241,10 +241,38 @@ bash tests/hermes-phaseB-gate.sh
 
 このシナリオでは、gate script が per-job コンテナ（`hermes-claude-<job_id>`）を dispatch 後に明示 `docker kill` し、`HERMES_WATCHDOG_SKIP_LOCK=1` を付けて `hermes/watchdog.sh` を最大 6 回（間に `sleep 2` を挟む）実行して、manifest が `status=failed` へ reconcile されること（`ac2b_watchdog_reconciles_killed_container_to_failed`）、および watchdog のログに reconcile 行と通知経路実行の文言（`reconciling status to failed (issue #122)` かつ `skipping notify for channel` または `notified (status=failed`）の両方が出力されること（`ac2b_notify_path_exercised`）を検証する。
 
-**オペレーター実測結果（未取得・記入待ち）**:
+**オペレーター実測結果（2026-07-23、docker socket 到達可能な host shell で実行）**: GO。
+
+初回〜3回目の実行では `ac2b_notify_path_exercised` が FAIL していたが、`watchdog.err` の全文を確認したところ `reconciling status to failed (issue #122)` の reconcile ログ自体は毎回正しく出力されており、原因は watchdog.sh ではなく gate script 側にあった。この環境では `SLACK_BOT_TOKEN` が実際に設定されているため `notify_slack` が本物の Slack API 呼び出しを行うが、gate script が使う偽チャンネル `C_PHASEB_GATE` は実在しないため Slack が `ok:false, error=channel_not_found` で reject する。`notify_slack` はこれを `Slack notify rejected for channel ... (ok:false, error=channel_not_found; will retry next pass)` としてログするが、gate script の grep は「token 未設定でスキップ」と「送信成功」の2パターンしか見ておらず、reject パターンを未実装のまま「通知経路が実行されていない」と誤判定していた。`tests/hermes-phaseB-gate.sh` の `NOTIFY_PATTERN` を4パターン（スキップ/送信エラー/reject/成功）すべてを許容するよう修正（commit `5dbd689`）した上で再実行し、GO を確認した。また同じ実行系列の中で、コンテナが `docker kill` より先に自然終了するケースの診断のため `docker inspect`/`docker logs`/`claude agents --json` を出力する診断コードと、FAIL 時に `WORK_DIR`（`watchdog.err` 含む）を保持するデバッグ用の変更（commit `cbc0711`, `a3b97b2`, `7cd499a`）も本 issue の一部として追加している。
+
+最終実行（全項目 PASS）:
 
 ```
-（ここに sandbox 外実行の ac2b_watchdog_reconciles_killed_container_to_failed / ac2b_notify_path_exercised の PASS/FAIL 行を追記する）
+=== hermes-phaseB go/no-go gate (AC-2, AC-3, フェーズB) ===
+  REPO_ROOT: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/.claude/worktrees/df-122
+  HERMES_AGENT_ROOT: /Users/naramotoyuuji/.hermes/hermes-agent
+  TARGET_REPO: it-all-playpark/dotfiles
+
+- ac2_dispatch_job_and_capture_manifest
+  PASS: ac2_dispatch_job_and_capture_manifest (invocation succeeded)
+- ac2_dispatch_container_running_before_kill
+  PASS: ac2_dispatch_container_running_before_kill
+- ac2_explicit_kill_of_dispatch_container
+  PASS: ac2_explicit_kill_of_dispatch_container
+- ac2b_watchdog_reconciles_killed_container_to_failed (up to 6 watchdog passes)
+  PASS: ac2b_watchdog_reconciles_killed_container_to_failed
+- ac2b_notify_path_exercised
+  PASS: ac2b_notify_path_exercised
+  AC-2 RESULT: RECONCILED -- per-job container killed -> watchdog
+               reconciled job to failed and notify path was
+               exercised (no auto-retry by design, issue #122).
+- ac3_claude_agents_reads_per_job_config_dir
+  PASS: ac3_claude_agents_reads_per_job_config_dir (uid=502, exit 0, JSON array returned)
+  AC-3 RESULT: GO -- non-root host user (uid=502) read
+               CLAUDE_CONFIG_DIR=/var/folders/ck/f0qvqvbd0fxb20mkgww4mfmc0000gp/T//hermes-phaseB-gate.josOfA/hermes-home/claude-state/job-d597af8b733d via `claude agents`
+               successfully. Record as confirmed in the decision-log.
+
+Results: 6 passed, 0 failed
 ```
 
 ### (4) issue #122 対応後のステータス（まとめテーブル更新）
@@ -255,4 +283,4 @@ bash tests/hermes-phaseB-gate.sh
 | オペレーターへの確実な通知 | **実装済み**（failed 確定後、既存 notify_dispatch/cleanup 経路に合流。gate script の `ac2b_notify_path_exercised` で検証設計） |
 | 自動再試行（コンテナ再起動・ジョブ再投入） | **非対応（運用制約として明記）**。手動でオペレーターが ChatOps コマンドを再実行する運用 |
 | AC-2 の NO-GO ギャップ | 上記実装により **解消**（reconcile + 通知で per-job コンテナ異常終了に対する回復力を確保）。長寿命 per-job コンテナモデルへの移行検討（フォローアップ 3.）は本 issue のスコープ外で別途扱う |
-| AC-2 相当シナリオの実機確認（gate script `ac2b_*`） | 本 implementer セッションでは sandbox 制約により SKIP。オペレーターによる sandbox 外再実行を依頼済み（上記(3)参照、結果は追記待ち） |
+| AC-2 相当シナリオの実機確認（gate script `ac2b_*`） | **実測 GO**（2026-07-23、オペレーターが docker socket 到達可能な host shell で実行、6 passed / 0 failed。上記(3)参照） |

--- a/claudedocs/hermes-phaseB-execution-model-decision.md
+++ b/claudedocs/hermes-phaseB-execution-model-decision.md
@@ -114,3 +114,145 @@ CLAUDE.md 運用ルール（sandbox で docker/gh 等が塞がれた場合は `d
 | AC-3 | GO（実機確認済み） | `tests/hermes-phaseB-gate.sh` を host 非root (`uid=502`) で実行し、`CLAUDE_CONFIG_DIR` 越しの `claude agents --json --cwd` が exit 0 + JSON 配列を返し、状態ファイルが指定ディレクトリに作成されることを確認 |
 
 **フォローアップ (Phase C 着手前の blocking 要件に格上げ)**: 上記「未確定事項・要フォローアップ」2. のとおり、S5 watchdog/reconcile 機構（または最低限の異常終了検知＋通知）を Phase C 着手前に設計・実装すること。
+
+## issue #122 対応: per-job コンテナ異常終了の検知と reconcile
+
+### (1) 採用方針
+
+上記フォローアップ 2. の選択肢 (a)（S5 watchdog を実装し failed へ確実に reconcile する）と (b)（少なくとも運用制約＋確実な通知を決定ログに残す）の**ハイブリッド**を採用した。
+
+`hermes/watchdog.sh` の `reconcile_job` に、`poll_bg_status` が `running` を返した場合の追加チェックとして `poll_container_state` を実装した。manifest の `container_id`（`dispatch.py` が dispatch 時点で既に永続化済み）に対し `docker inspect -f '{{.State.Running}}' <container_id>` を実行し、結果を **alive / dead / unknown** の 3 値に分類する:
+
+- **alive**（`Running=true`）: `container_dead_streak` を 0 にリセットして `running` のまま return する。正常完了直前の一時的 dead 観測（`--rm` レース）による誤蓄積を防ぐため。
+- **dead**（`Running=false`、または `docker inspect` が `no such object` エラーで失敗＝`--rm` 済み）: `container_dead_streak` をインクリメントする。`HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT`（デフォルト 2）連続で dead を観測して初めて `status=failed` を確定し、既存の notify/cleanup パイプラインに合流させる。単発の dead 観測では確定しない。
+- **unknown**（`docker` が PATH に無い、または daemon 接続エラー等 `no such object` 以外の失敗）: `container_dead_streak` を**一切変更しない**。daemon 再起動のたびに検知蓄積が消えて誤って検知が遅延する、または daemon 不達を理由に安易に failed 化する、のどちらも避けるための設計。
+
+`container_id` が空/null の manifest（issue #122 以前に dispatch された旧ジョブ）はこの死活チェックを完全にスキップし、従来どおり `poll_bg_status` のみで reconcile する（後方互換）。
+
+failed 確定後は、既存の `notify_dispatch` / cleanup 経路（Slack/Discord 通知、`notified` フラグによる冪等化、cleanup）にそのまま合流するため、per-job コンテナが異常終了したジョブはオペレーターへ確実に通知される。
+
+**運用制約（明示）**: **自動再試行（コンテナの再起動・ジョブの再投入）は実装しない**。per-job コンテナが落ちて `failed` 通知を受けたジョブは、オペレーターが手動で ChatOps コマンドを再実行し再 dispatch する運用とする。これは今回のスコープでの意図的な選択であり、将来的に自動再試行が必要になった場合は別途設計・決定する。
+
+**検知〜通知レイテンシ**: launchd `com.playpark.hermes-watchdog` は `StartInterval=120` 秒で起動する（`home-manager/home/default.nix`, `hermes/README.md` に既述）。`CONTAINER_DEAD_CONFIRM_COUNT=2` 連続確認が必要なため、コンテナ死亡から通知までの最悪ケースのレイテンシは**約 4〜6 分**（2 パス分の 120 秒間隔 ± 実行タイミングのずれ）である。
+
+**docker events 購読を採らなかった理由**: `docker events` によるストリーミング購読は、実装がシンプルで検知遅延も理論上ゼロに近づけられる一方、常駐プロセスとして動き続ける必要があり、現行の watchdog は launchd `StartInterval` による周期起動（起動のたびに新規プロセスとして起動し、実行後に終了する）モデルを前提にしている。常駐化には別途プロセス管理（launchd `KeepAlive` 化、再起動時の状態復元、二重起動防止の見直し等）が必要になり、issue #122 が要求する「異常終了の検知と reconcile」に対しては poll ベースで十分満たせるため、常駐プロセスの追加は YAGNI と判断した。
+
+### (2) 検証エビデンス
+
+`~/.hermes/hermes-agent/venv/bin/python -m pytest hermes/plugins/claude_runner/tests -v` を本 implementer セッションで実行した結果（`test_watchdog_container.py` の 7 ケースを含む全 54 ケースが PASS）:
+
+```
+============================= test session starts ==============================
+platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /Users/naramotoyuuji/.hermes/hermes-agent/venv/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/.claude/worktrees/df-122
+plugins: xdist-3.8.0, split-0.11.0, asyncio-1.3.0, anyio-4.13.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_fixture_loop_scope=None
+collected 54 items
+
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_unbound_channel_is_refused_without_side_effects PASSED [  1%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_repo_override_not_bound_to_channel_is_refused PASSED [  3%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_bound_channel_dispatches_with_correct_host_and_container_paths PASSED [  5%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_bound_channel_with_multiple_repos_fans_out_one_job_per_repo PASSED [  7%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_docker_launch_failure_marks_manifest_failed_and_reports_error PASSED [  9%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_malformed_bindings_file_is_fail_closed PASSED [ 11%]
+hermes/plugins/claude_runner/tests/test_dispatch.py::test_missing_required_args_returns_tool_error PASSED [ 12%]
+hermes/plugins/claude_runner/tests/test_docker_bg_smoke.py::test_bg_job_id_is_read_from_container_logs_not_run_stdout PASSED [ 14%]
+hermes/plugins/claude_runner/tests/test_docker_bg_smoke.py::test_bg_job_id_matches_claude_agents_listing_container_id_does_not PASSED [ 16%]
+hermes/plugins/claude_runner/tests/test_docker_bg_smoke.py::test_docker_run_stdout_empty_raises_dispatch_error PASSED [ 18%]
+hermes/plugins/claude_runner/tests/test_docker_bg_smoke.py::test_missing_bg_job_id_in_logs_raises_after_poll_timeout PASSED [ 20%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_multi_repo_bind_fans_out_to_independent_jobs PASSED [ 22%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_running_at_cap_returns_congested_with_no_new_dispatch PASSED [ 24%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_pending_job_also_counts_toward_the_cap PASSED [ 25%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_below_cap_dispatches_normally PASSED [ 27%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_done_job_does_not_count_toward_the_cap PASSED [ 29%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_malformed_bindings_file_rejects_the_bind_with_no_side_effects PASSED [ 31%]
+hermes/plugins/claude_runner/tests/test_fanout_limit.py::test_invalid_repo_slug_in_bindings_rejects_the_bind PASSED [ 33%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_dispatch_job_with_unbound_channel_is_blocked PASSED [ 35%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_dispatch_job_with_repo_override_not_bound_is_blocked PASSED [ 37%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_dispatch_job_with_invalid_bindings_schema_is_blocked PASSED [ 38%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_dispatch_job_with_missing_required_args_is_blocked PASSED [ 40%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_dispatch_job_with_bound_channel_is_allowed PASSED [ 42%]
+hermes/plugins/claude_runner/tests/test_guard.py::test_other_tool_name_is_passed_through PASSED [ 44%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_register_adds_dispatch_job_to_registry PASSED [ 46%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_dispatch_job_stub_returns_error_json PASSED [ 48%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_manifest_round_trip_keeps_host_and_container_paths_separate PASSED [ 50%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_manifest_rejects_invalid_status PASSED [ 51%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_manifest_rejects_missing_field PASSED [ 53%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_valid_file_loads PASSED [ 55%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[not_platforms: {}\n] PASSED [ 57%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[platforms:\n  slack: not-a-mapping\n] PASSED [ 59%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[platforms:\n  slack:\n    channels: {}\n] PASSED [ 61%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[platforms:\n  slack:\n    channels:\n      C1: {}\n] PASSED [ 62%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[platforms:\n  slack:\n    channels:\n      C1:\n        repos: []\n] PASSED [ 64%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_bindings_invalid_schema_raises[platforms:\n  slack:\n    channels:\n      C1:\n        repos:\n          - not-a-slug\n] PASSED [ 66%]
+hermes/plugins/claude_runner/tests/test_registration.py::test_repo_bindings_sample_file_is_valid PASSED [ 68%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_container_alive_keeps_running_with_zero_streak PASSED [ 70%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_container_no_such_object_confirms_dead_after_two_passes_then_failed PASSED [ 72%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_container_exited_running_false_counts_as_dead_observation PASSED [ 74%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_docker_daemon_unreachable_leaves_existing_streak_unchanged PASSED [ 75%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_container_alive_resets_existing_streak_to_zero PASSED [ 77%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_manifest_without_container_id_skips_container_check PASSED [ 79%]
+hermes/plugins/claude_runner/tests/test_watchdog_container.py::test_bg_session_completed_takes_priority_over_dead_container PASSED [ 81%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_notified_false_triggers_single_notify_and_flips_true PASSED [ 83%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_notified_true_skips_notify_and_triggers_cleanup PASSED [ 85%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_failed_status_notified_once_like_done PASSED [ 87%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_running_job_with_still_running_bg_session_is_untouched PASSED [ 88%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_running_job_with_completed_bg_session_reconciles_then_notifies PASSED [ 90%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_slack_ok_false_body_is_treated_as_notify_failure_and_retried PASSED [ 92%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_discord_platform_notifies_via_discord_api_not_slack PASSED [ 94%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_unknown_platform_has_no_adapter_and_makes_no_network_call PASSED [ 96%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_freshly_dispatched_job_absent_from_listing_stays_running_within_grace PASSED [ 98%]
+hermes/plugins/claude_runner/tests/test_watchdog_notify.py::test_absent_job_past_grace_requires_consecutive_confirmations_before_done PASSED [100%]
+
+============================== 54 passed in 8.61s ==============================
+```
+
+### (3) AC-2 相当シナリオの実機確認
+
+`bash tests/hermes-phaseB-gate.sh` を本 implementer セッション（sandboxed Bash tool）で実行した。本セッションは docker daemon ソケットへの接続が権限で拒否される環境であり、AC-2 セクションは既存の安全側フォールバックにより SKIP に倒れた:
+
+```
+=== hermes-phaseB go/no-go gate (AC-2, AC-3, フェーズB) ===
+  REPO_ROOT: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/dotfiles/.claude/worktrees/df-122
+  HERMES_AGENT_ROOT: /Users/naramotoyuuji/.hermes/hermes-agent
+  TARGET_REPO: it-all-playpark/dotfiles
+
+NOTE: docker daemon not reachable from this shell -- AC-2 section will
+      be SKIPped. Re-run this script from a shell with real docker
+      socket access (outside any agent sandbox) to get an AC-2 verdict.
+  SKIP: ac2_dispatch_container_kill_and_progress (docker daemon not reachable from this shell)
+- ac3_claude_agents_reads_per_job_config_dir
+  PASS: ac3_claude_agents_reads_per_job_config_dir (uid=502, exit 0, JSON array returned)
+  AC-3 RESULT: GO -- non-root host user (uid=502) read
+               CLAUDE_CONFIG_DIR=/tmp/claude-502/hermes-phaseB-gate.w2oFxS/claude-state/scratch-job via `claude agents`
+               successfully. Record as confirmed in the decision-log.
+
+Results: 1 passed, 0 failed
+```
+
+CLAUDE.md 運用ルール（sandbox で docker 等が塞がれた場合は `dangerouslyDisableSandbox` で勝手に緩めず、失敗を報告して設定調整を提案する）に従い、本セッションでは sandbox を回避せず、この制約をそのまま報告する。
+
+**オペレーターへの依頼（sandbox 外での再実行手順）**: docker socket に到達可能な host shell（sandbox 外）で以下を実行し、`ac2b_watchdog_reconciles_killed_container_to_failed` / `ac2b_notify_path_exercised` の PASS/FAIL 行を本セクションへ追記すること。
+
+```
+bash tests/hermes-phaseB-gate.sh
+```
+
+このシナリオでは、gate script が per-job コンテナ（`hermes-claude-<job_id>`）を dispatch 後に明示 `docker kill` し、`HERMES_WATCHDOG_SKIP_LOCK=1` を付けて `hermes/watchdog.sh` を最大 6 回（間に `sleep 2` を挟む）実行して、manifest が `status=failed` へ reconcile されること（`ac2b_watchdog_reconciles_killed_container_to_failed`）、および watchdog のログに reconcile 行と通知経路実行の文言（`reconciling status to failed (issue #122)` かつ `skipping notify for channel` または `notified (status=failed`）の両方が出力されること（`ac2b_notify_path_exercised`）を検証する。
+
+**オペレーター実測結果（未取得・記入待ち）**:
+
+```
+（ここに sandbox 外実行の ac2b_watchdog_reconciles_killed_container_to_failed / ac2b_notify_path_exercised の PASS/FAIL 行を追記する）
+```
+
+### (4) issue #122 対応後のステータス（まとめテーブル更新）
+
+| 項目 | ステータス |
+|------|-----------|
+| per-job コンテナ異常終了の検知・reconcile | **実装済み**（`watchdog.sh` の `poll_container_state` + `CONTAINER_DEAD_CONFIRM_COUNT` streak、pytest 54/54 PASS で検証） |
+| オペレーターへの確実な通知 | **実装済み**（failed 確定後、既存 notify_dispatch/cleanup 経路に合流。gate script の `ac2b_notify_path_exercised` で検証設計） |
+| 自動再試行（コンテナ再起動・ジョブ再投入） | **非対応（運用制約として明記）**。手動でオペレーターが ChatOps コマンドを再実行する運用 |
+| AC-2 の NO-GO ギャップ | 上記実装により **解消**（reconcile + 通知で per-job コンテナ異常終了に対する回復力を確保）。長寿命 per-job コンテナモデルへの移行検討（フォローアップ 3.）は本 issue のスコープ外で別途扱う |
+| AC-2 相当シナリオの実機確認（gate script `ac2b_*`） | 本 implementer セッションでは sandbox 制約により SKIP。オペレーターによる sandbox 外再実行を依頼済み（上記(3)参照、結果は追記待ち） |

--- a/hermes/plugins/claude_runner/tests/test_watchdog_container.py
+++ b/hermes/plugins/claude_runner/tests/test_watchdog_container.py
@@ -1,0 +1,382 @@
+"""Tests for ``hermes/watchdog.sh``'s per-job container死活検知 (issue #122).
+
+``watchdog.sh``'s ``reconcile_job`` previously judged a job's liveness purely
+from ``poll_bg_status`` (a ``claude agents --json`` listing). If the bg
+session's own manifest still said ``running`` but its per-job Docker
+container had actually been killed/OOM-killed/removed by a daemon restart,
+the job would be polled forever with no path to ``failed`` (issue #122 /
+AC-2 NO-GO).
+
+This adds a second, independent signal: ``poll_container_state`` runs
+``docker inspect -f '{{.State.Running}}' <container_id>`` and classifies the
+result as ``alive`` / ``dead`` / ``unknown``. Only ``dead`` observed for
+``HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT`` (default 2) *consecutive*
+reconcile passes forces the job to ``failed`` (falling through into the
+existing notify/cleanup pipeline, same as the reaper paths already covered
+by ``test_watchdog_notify.py``). ``alive`` resets the streak; ``unknown``
+(docker unreachable) leaves the streak untouched so a daemon restart never
+manufactures a false failure nor silently drops already-observed dead
+passes.
+
+Like ``test_watchdog_notify.py``, ``watchdog.sh`` is exercised as a real
+subprocess with real ``jq`` -- only ``curl`` (Slack), ``claude`` (bg session
+polling) and now ``docker`` (container liveness) are stubbed via a
+PATH-prepended fake-bin dir.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+HERMES_AGENT_ROOT = Path(
+    os.environ.get("HERMES_AGENT_ROOT", "~/.hermes/hermes-agent")
+).expanduser()
+
+for _path in (str(HERMES_AGENT_ROOT), str(REPO_ROOT / "hermes" / "plugins")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+pytest.importorskip("tools.registry", reason="hermes-agent venv not available")
+
+from claude_runner import manifest as manifest_mod  # noqa: E402
+
+WATCHDOG_SH = REPO_ROOT / "hermes" / "watchdog.sh"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_manifest_dirs(tmp_path, monkeypatch):
+    monkeypatch.setattr(manifest_mod, "JOBS_DIR", tmp_path / "hermes" / "jobs")
+    monkeypatch.setattr(
+        manifest_mod, "WORKSPACES_DIR", tmp_path / "hermes" / "workspaces"
+    )
+    monkeypatch.setattr(
+        manifest_mod, "CLAUDE_STATE_DIR", tmp_path / "hermes" / "claude-state"
+    )
+    yield
+
+
+def _write_job(
+    *,
+    status,
+    notified,
+    bg_job_id="bg-job-1",
+    job_id="job-watchdog-container-1",
+    platform="slack",
+    channel="C0123456789",
+    created_at=None,
+    container_id="container-abc-1",
+    container_dead_streak=None,
+):
+    """Build + write a manifest (optionally with ``container_id``), then
+    materialize its workspace/claude-state host dirs on disk. ``created_at``
+    defaults to 10 minutes ago so the REAP_TIMEOUT_SECONDS (default 5400s)
+    reaper never fires and the ABSENT_GRACE window is trivially satisfied
+    for the still-listed-running bg session assertions below."""
+    manifest = manifest_mod.build_manifest(
+        job_id=job_id,
+        platform=platform,
+        channel=channel,
+        repo="it-all-playpark/dotfiles",
+        origin_url="git@github.com:it-all-playpark/dotfiles.git",
+        container_id=container_id,
+        bg_job_id=bg_job_id,
+        status=status,
+        notified=notified,
+        created_at=created_at if created_at is not None else time.time() - 600,
+    )
+    if container_dead_streak is not None:
+        manifest["container_dead_streak"] = container_dead_streak
+    manifest_mod.write_manifest(manifest)
+    Path(manifest["workspace_host_dir"]).mkdir(parents=True, exist_ok=True)
+    (Path(manifest["workspace_host_dir"]) / "marker.txt").write_text("clone\n")
+    Path(manifest["claude_config_host_dir"]).mkdir(parents=True, exist_ok=True)
+    return manifest
+
+
+def _fake_bin_dir(
+    tmp_path,
+    *,
+    curl_log,
+    claude_agents_json=None,
+    curl_response='{"ok":true}',
+    curl_http_status="200",
+    curl_exit_code=0,
+):
+    """Build a PATH-prependable dir with fake curl (Slack), claude (bg
+    session polling) and docker (container liveness). The fake docker's
+    behavior is selected at *runtime* via the ``FAKE_DOCKER_MODE`` env var
+    (alive/exited/no_such/daemon_down) so a single script serves every test
+    case below."""
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir()
+
+    curl_script = bin_dir / "curl"
+    curl_script.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf \'%s\\n\' "$*" | tr \'\\n\' \' \' >> "{curl_log}"\n'
+        f'printf \'\\n\' >> "{curl_log}"\n'
+        "has_w=0\n"
+        'for a in "$@"; do\n'
+        '  if [ "$a" = "-w" ]; then has_w=1; fi\n'
+        "done\n"
+        f"printf '%s' {shlex.quote(curl_response)}\n"
+        'if [ "$has_w" = "1" ]; then\n'
+        f"  printf '\\n%s' {shlex.quote(curl_http_status)}\n"
+        "fi\n"
+        f"exit {curl_exit_code}\n"
+    )
+    curl_script.chmod(0o755)
+
+    claude_script = bin_dir / "claude"
+    payload = claude_agents_json if claude_agents_json is not None else "[]"
+    claude_script.write_text(
+        "#!/usr/bin/env bash\n" f"cat <<'CLAUDE_JSON'\n{payload}\nCLAUDE_JSON\n"
+    )
+    claude_script.chmod(0o755)
+
+    docker_script = bin_dir / "docker"
+    docker_script.write_text(
+        "#!/usr/bin/env bash\n"
+        'mode="${FAKE_DOCKER_MODE:-alive}"\n'
+        'case "$mode" in\n'
+        "  alive)\n"
+        '    echo "true"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "  exited)\n"
+        '    echo "false"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "  no_such)\n"
+        '    echo "Error: No such object: xxx" >&2\n'
+        "    exit 1\n"
+        "    ;;\n"
+        "  daemon_down)\n"
+        '    echo "Cannot connect to the Docker daemon" >&2\n'
+        "    exit 1\n"
+        "    ;;\n"
+        "  *)\n"
+        '    echo "true"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+    )
+    docker_script.chmod(0o755)
+
+    return bin_dir
+
+
+def _run_watchdog(
+    tmp_path, *, bin_dir, slack_bot_token="xoxb-fake-token", extra_env=None
+):
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path / "hermes")
+    env["HERMES_WATCHDOG_SKIP_LOCK"] = "1"
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    if slack_bot_token is not None:
+        env["SLACK_BOT_TOKEN"] = slack_bot_token
+    else:
+        env.pop("SLACK_BOT_TOKEN", None)
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        ["bash", str(WATCHDOG_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"watchdog.sh exited {result.returncode}\nstdout={result.stdout}\n"
+        f"stderr={result.stderr}"
+    )
+    return result
+
+
+_STILL_RUNNING_JSON = json.dumps([{"id": "bg-job-1", "status": "running"}])
+_COMPLETED_JSON = json.dumps([{"id": "bg-job-1", "status": "completed"}])
+
+
+# ---------------------------------------------------------------------------
+# 1. bg session still listed running + container alive -> stays running,
+#    container_dead_streak 0.
+# ---------------------------------------------------------------------------
+
+
+def test_container_alive_keeps_running_with_zero_streak(tmp_path):
+    manifest = _write_job(status="running", notified=False)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "alive"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "running"
+    assert updated.get("container_dead_streak", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. bg session still listed running + container gone (--rm'd, "no such
+#    object") -> first pass increments the streak but stays running; the
+#    *second* consecutive pass reconciles to failed and notifies exactly
+#    once (issue #122).
+# ---------------------------------------------------------------------------
+
+
+def test_container_no_such_object_confirms_dead_after_two_passes_then_failed(
+    tmp_path,
+):
+    manifest = _write_job(status="running", notified=False)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+    env = {"FAKE_DOCKER_MODE": "no_such"}
+
+    _run_watchdog(tmp_path, bin_dir=bin_dir, extra_env=env)
+    after_pass1 = manifest_mod.read_manifest(manifest["job_id"])
+    assert after_pass1["status"] == "running"
+    assert after_pass1["container_dead_streak"] == 1
+    calls_after_pass1 = curl_log.read_text().splitlines() if curl_log.exists() else []
+    assert calls_after_pass1 == []
+
+    _run_watchdog(tmp_path, bin_dir=bin_dir, extra_env=env)
+    after_pass2 = manifest_mod.read_manifest(manifest["job_id"])
+    assert after_pass2["status"] == "failed"
+    assert after_pass2["notified"] is True
+    calls = curl_log.read_text().splitlines() if curl_log.exists() else []
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. `docker inspect` succeeds (exit 0) but reports Running=false (container
+#    exited, not yet removed) -> counts as a dead observation too.
+# ---------------------------------------------------------------------------
+
+
+def test_container_exited_running_false_counts_as_dead_observation(tmp_path):
+    manifest = _write_job(status="running", notified=False)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "exited"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "running"
+    assert updated["container_dead_streak"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. docker daemon unreachable ("Cannot connect to the Docker daemon") with
+#    a pre-existing dead streak of 1 -> streak must NOT change (unknown is
+#    not a reset, and it is not an increment either) and status stays
+#    running.
+# ---------------------------------------------------------------------------
+
+
+def test_docker_daemon_unreachable_leaves_existing_streak_unchanged(tmp_path):
+    manifest = _write_job(
+        status="running", notified=False, container_dead_streak=1
+    )
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "daemon_down"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "running"
+    assert updated["container_dead_streak"] == 1
+    calls = curl_log.read_text().splitlines() if curl_log.exists() else []
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# 5. A pre-existing dead streak of 1 is reset to 0 once the container is
+#    observed alive again.
+# ---------------------------------------------------------------------------
+
+
+def test_container_alive_resets_existing_streak_to_zero(tmp_path):
+    manifest = _write_job(
+        status="running", notified=False, container_dead_streak=1
+    )
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "alive"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "running"
+    assert updated["container_dead_streak"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Backward compatibility: a manifest with no container_id (pre-#122
+#    dispatch) must skip container liveness checking entirely, even when the
+#    fake docker would report the container gone -- no container_dead_streak
+#    field should ever be created for it.
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_without_container_id_skips_container_check(tmp_path):
+    manifest = _write_job(status="running", notified=False, container_id=None)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "no_such"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "running"
+    assert "container_dead_streak" not in updated
+
+
+# ---------------------------------------------------------------------------
+# 7. The bg session listing itself reports completion (poll_bg_status ->
+#    done) even though the container is gone -- the normal completion path
+#    takes priority and the job is reconciled to `done`, never `failed`.
+# ---------------------------------------------------------------------------
+
+
+def test_bg_session_completed_takes_priority_over_dead_container(tmp_path):
+    manifest = _write_job(status="running", notified=False)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_COMPLETED_JSON
+    )
+
+    _run_watchdog(
+        tmp_path, bin_dir=bin_dir, extra_env={"FAKE_DOCKER_MODE": "no_such"}
+    )
+
+    updated = manifest_mod.read_manifest(manifest["job_id"])
+    assert updated["status"] == "done"
+    assert updated["notified"] is True

--- a/hermes/plugins/claude_runner/tests/test_watchdog_container.py
+++ b/hermes/plugins/claude_runner/tests/test_watchdog_container.py
@@ -114,8 +114,8 @@ def _fake_bin_dir(
     """Build a PATH-prependable dir with fake curl (Slack), claude (bg
     session polling) and docker (container liveness). The fake docker's
     behavior is selected at *runtime* via the ``FAKE_DOCKER_MODE`` env var
-    (alive/exited/no_such/daemon_down) so a single script serves every test
-    case below."""
+    (alive/alive_with_stderr_warning/exited/no_such/daemon_down) so a single
+    script serves every test case below."""
     bin_dir = tmp_path / "fakebin"
     bin_dir.mkdir()
 
@@ -149,6 +149,11 @@ def _fake_bin_dir(
         'mode="${FAKE_DOCKER_MODE:-alive}"\n'
         'case "$mode" in\n'
         "  alive)\n"
+        '    echo "true"\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "  alive_with_stderr_warning)\n"
+        '    echo "WARNING: could not read /etc/docker/config.json" >&2\n'
         '    echo "true"\n'
         "    exit 0\n"
         "    ;;\n"
@@ -259,6 +264,39 @@ def test_container_no_such_object_confirms_dead_after_two_passes_then_failed(
     assert after_pass2["notified"] is True
     calls = curl_log.read_text().splitlines() if curl_log.exists() else []
     assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2b. `docker inspect` succeeds (exit 0) but also writes a warning to stderr
+#    (e.g. a config-file parse warning) -- stdout/stderr must be captured
+#    separately so the warning text never gets mixed into the "true"/"false"
+#    comparison. A running container must stay `alive` (streak 0), not be
+#    misclassified as `dead` (issue #123 review).
+# ---------------------------------------------------------------------------
+
+
+def test_container_alive_with_stderr_warning_is_not_misdetected_as_dead(tmp_path):
+    manifest = _write_job(status="running", notified=False)
+    curl_log = tmp_path / "curl.log"
+    bin_dir = _fake_bin_dir(
+        tmp_path, curl_log=curl_log, claude_agents_json=_STILL_RUNNING_JSON
+    )
+    env = {"FAKE_DOCKER_MODE": "alive_with_stderr_warning"}
+
+    _run_watchdog(tmp_path, bin_dir=bin_dir, extra_env=env)
+    after_pass1 = manifest_mod.read_manifest(manifest["job_id"])
+    assert after_pass1["status"] == "running"
+    assert after_pass1.get("container_dead_streak", 0) == 0
+
+    # A second consecutive pass must not accumulate a dead streak either --
+    # the previous bug's persistent stderr warning would have kept forcing
+    # "dead" on every pass, eventually flipping the job to failed.
+    _run_watchdog(tmp_path, bin_dir=bin_dir, extra_env=env)
+    after_pass2 = manifest_mod.read_manifest(manifest["job_id"])
+    assert after_pass2["status"] == "running"
+    assert after_pass2.get("container_dead_streak", 0) == 0
+    calls = curl_log.read_text().splitlines() if curl_log.exists() else []
+    assert calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/hermes/watchdog.sh
+++ b/hermes/watchdog.sh
@@ -292,14 +292,27 @@ poll_bg_status() {
 #     which is why the CONTAINER_DEAD_CONFIRM_COUNT streak — not a single
 #     observation — is what actually forces `failed`, see reconcile_job).
 #   - anything else (daemon unreachable, permission error, etc.) -> unknown.
+#
+# stdout and stderr are captured separately (never `2>&1`): `docker inspect`
+# can exit 0 while still writing warnings to stderr (e.g. config-file parse
+# warnings), which would otherwise land in `out` ahead of the `true`/`false`
+# line and make the `[ "$out" = "true" ]` comparison fail for a container
+# that is actually still running -- misclassifying it as `dead`. On the
+# `dead`-streak path (CONTAINER_DEAD_CONFIRM_COUNT consecutive `dead`
+# passes) that would eventually flip a live job to `failed`, trigger the
+# notify path, and let `cleanup_job` `rm -rf` its still-in-use workspace.
+# stderr is only ever consulted on a non-zero exit, to match it against
+# "no such object".
 poll_container_state() {
   local container_id="$1"
   if ! command -v docker >/dev/null 2>&1; then
     echo "unknown"
     return
   fi
-  local out
-  if out=$(docker inspect -f '{{.State.Running}}' "$container_id" 2>&1); then
+  local out stderr_file
+  stderr_file=$(mktemp)
+  if out=$(docker inspect -f '{{.State.Running}}' "$container_id" 2>"$stderr_file"); then
+    rm -f -- "$stderr_file"
     if [ "$out" = "true" ]; then
       echo "alive"
     else
@@ -307,9 +320,11 @@ poll_container_state() {
     fi
     return
   fi
-  if printf '%s' "$out" | grep -qi 'no such object'; then
+  if grep -qi 'no such object' "$stderr_file" 2>/dev/null; then
+    rm -f -- "$stderr_file"
     echo "dead"
   else
+    rm -f -- "$stderr_file"
     echo "unknown"
   fi
 }

--- a/hermes/watchdog.sh
+++ b/hermes/watchdog.sh
@@ -109,6 +109,47 @@
 #                             the only way to reclaim its slot/workspace,
 #                             since notify for that platform can never
 #                             succeed. Default 5400 (90 minutes).
+#   HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT
+#                             Per-job container 死活検知 (issue #122 / AC-2):
+#                             `poll_bg_status` alone only reflects what the
+#                             bg session's own listing reports — if the
+#                             per-job Docker container is killed/OOM-killed
+#                             or vanishes on a daemon restart while that
+#                             listing still says `running`, reconcile_job
+#                             would otherwise poll the job forever with no
+#                             path to `failed`. When a manifest's
+#                             `container_id` is non-empty and `poll_bg_status`
+#                             returns `running`, `poll_container_state` runs
+#                             `docker inspect -f '{{.State.Running}}'` against
+#                             it and classifies the result:
+#                               - alive   -> `container_dead_streak` is reset
+#                                 to 0 (guards against a transient dead
+#                                 observation right before a legitimate
+#                                 `--rm` completion race).
+#                               - unknown (docker missing from PATH, or a
+#                                 daemon-connect error not matching "no such
+#                                 object") -> `container_dead_streak` is left
+#                                 completely unchanged — a daemon restart
+#                                 must never manufacture a false failure NOR
+#                                 silently erase dead passes already observed.
+#                               - dead (inspect reports Running=false, or
+#                                 fails with a "no such object" error, i.e.
+#                                 the container was --rm'd) -> increments
+#                                 `container_dead_streak`; once it reaches
+#                                 this threshold for CONSECUTIVE passes,
+#                                 `status` is forced to `failed` and falls
+#                                 through into the normal notify/cleanup
+#                                 pipeline below (same shape as the existing
+#                                 reap paths). This script never restarts the
+#                                 container nor re-dispatches the job on its
+#                                 own — that is a deliberate operational
+#                                 constraint (see
+#                                 claudedocs/hermes-phaseB-execution-model-decision.md),
+#                                 an operator must re-run the ChatOps command
+#                                 manually after being notified. A manifest
+#                                 with no `container_id` (pre-#122 dispatch)
+#                                 skips this check entirely for backward
+#                                 compatibility. Default 2.
 #
 # notify dispatch (manifest.platform):
 #   `notify_slack` and `notify_discord` are the only real network sends;
@@ -155,6 +196,7 @@ acquire_lock_or_exit() {
 ABSENT_GRACE_SECONDS="${HERMES_WATCHDOG_ABSENT_GRACE_SECONDS:-60}"
 ABSENT_CONFIRM_COUNT="${HERMES_WATCHDOG_ABSENT_CONFIRM_COUNT:-3}"
 REAP_TIMEOUT_SECONDS="${HERMES_WATCHDOG_REAP_TIMEOUT_SECONDS:-5400}"
+CONTAINER_DEAD_CONFIRM_COUNT="${HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT:-2}"
 
 # manifest.created_at is a float (Python time.time()); compute integer age
 # with awk rather than bash arithmetic (no float support) or `awk systime()`
@@ -234,6 +276,42 @@ poll_bg_status() {
       echo "done"
       ;;
   esac
+}
+
+# Per-job container liveness check (issue #122 / AC-2). Echoes one of:
+# alive | dead | unknown
+#
+# `docker` missing from PATH -> unknown (can't tell either way, never
+# manufacture a false failure just because this host has no docker CLI).
+# `docker inspect -f '{{.State.Running}}' <container_id>` exit 0:
+#   - stdout == "true"  -> alive
+#   - stdout != "true"  -> dead (exited but not yet --rm'd)
+# `docker inspect` non-zero exit:
+#   - stderr matches "no such object" (case-insensitive) -> dead (the
+#     container was --rm'd, the expected shape for a normal completion too,
+#     which is why the CONTAINER_DEAD_CONFIRM_COUNT streak — not a single
+#     observation — is what actually forces `failed`, see reconcile_job).
+#   - anything else (daemon unreachable, permission error, etc.) -> unknown.
+poll_container_state() {
+  local container_id="$1"
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "unknown"
+    return
+  fi
+  local out
+  if out=$(docker inspect -f '{{.State.Running}}' "$container_id" 2>&1); then
+    if [ "$out" = "true" ]; then
+      echo "alive"
+    else
+      echo "dead"
+    fi
+    return
+  fi
+  if printf '%s' "$out" | grep -qi 'no such object'; then
+    echo "dead"
+  else
+    echo "unknown"
+  fi
 }
 
 # Slack's chat.postMessage returns HTTP 200 + body `{"ok":false,"error":...}`
@@ -393,11 +471,50 @@ reconcile_job() {
       local polled
       polled=$(poll_bg_status "$manifest_path" "$claude_config_host_dir" "$workspace_host_dir" "$bg_job_id" "$created_at")
       if [ "$polled" = "running" ]; then
-        log "job $job_id still running — skipping"
-        return
+        # bg session listing still says running — cross-check the per-job
+        # container's own liveness (issue #122 / AC-2): a killed/OOM'd/
+        # daemon-restart-vanished container can otherwise be polled forever
+        # since poll_bg_status alone never observes it.
+        local container_id
+        container_id=$(jq -r '.container_id // empty' "$manifest_path")
+        if [ -z "$container_id" ]; then
+          # Pre-#122 manifest with no container_id recorded — skip the
+          # check entirely, preserving prior behavior.
+          log "job $job_id still running — skipping"
+          return
+        fi
+        local cstate
+        cstate=$(poll_container_state "$container_id")
+        case "$cstate" in
+          alive)
+            if [ "$(jq -r '.container_dead_streak // 0' "$manifest_path" 2>/dev/null || echo 0)" != "0" ]; then
+              set_manifest_field "$manifest_path" "container_dead_streak" "0"
+            fi
+            log "job $job_id still running — skipping"
+            return
+            ;;
+          unknown)
+            log "job $job_id container state unknown (docker unavailable) — leaving container_dead_streak unchanged"
+            return
+            ;;
+          dead)
+            local streak
+            streak=$(jq -r '.container_dead_streak // 0' "$manifest_path" 2>/dev/null || echo 0)
+            streak=$((streak + 1))
+            set_manifest_field "$manifest_path" "container_dead_streak" "$streak"
+            if [ "$streak" -lt "$CONTAINER_DEAD_CONFIRM_COUNT" ]; then
+              log "job $job_id per-job container $container_id observed dead ($streak/$CONTAINER_DEAD_CONFIRM_COUNT consecutive passes) — not yet reconciling"
+              return
+            fi
+            log "job $job_id per-job container $container_id dead for $streak consecutive passes while bg session still listed running — reconciling status to failed (issue #122)"
+            status="failed"
+            set_manifest_field "$manifest_path" "status" '"failed"'
+            ;;
+        esac
+      else
+        status="$polled"
+        set_manifest_field "$manifest_path" "status" "\"$status\""
       fi
-      status="$polled"
-      set_manifest_field "$manifest_path" "status" "\"$status\""
     fi
   fi
 

--- a/tests/hermes-claude-runner.test.sh
+++ b/tests/hermes-claude-runner.test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # tests/hermes-claude-runner.test.sh
-# Runs the claude_runner plugin scaffold's pytest suite using the installed
-# hermes-agent venv Python. `tools.registry`, `hermes_cli.plugins`, etc. are
-# only importable from that venv/checkout — this repo does not vendor a
-# second hermes-agent dependency set.
+# Runs the claude_runner plugin's full pytest suite (hermes/plugins/claude_runner/tests)
+# using the installed hermes-agent venv Python. `tools.registry`, `hermes_cli.plugins`,
+# etc. are only importable from that venv/checkout — this repo does not vendor a
+# second hermes-agent dependency set. Every test file in that directory self-guards
+# via `pytest.importorskip("tools.registry", ...)` when the venv/checkout is absent,
+# and mocks out docker/git/network via subprocess.run monkeypatching, so running the
+# whole directory is safe even without a full hermes-agent environment.
 #
 # Usage:
 #   bash tests/hermes-claude-runner.test.sh
@@ -31,4 +34,4 @@ fi
 
 export HERMES_AGENT_ROOT
 cd "${REPO_ROOT}"
-exec "${VENV_PYTHON}" -m pytest hermes/plugins/claude_runner/tests/test_registration.py -v
+exec "${VENV_PYTHON}" -m pytest hermes/plugins/claude_runner/tests -v

--- a/tests/hermes-phaseB-gate.sh
+++ b/tests/hermes-phaseB-gate.sh
@@ -83,7 +83,22 @@ if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
 fi
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hermes-phaseB-gate.XXXXXX")"
-trap 'rm -rf "${WORK_DIR}"' EXIT
+_cleanup_work_dir() {
+  # Debug aid (issue #122 follow-up): on failure, keep WORK_DIR (watchdog.err,
+  # container_diag.txt, dispatch.err, etc.) around instead of silently
+  # deleting the only evidence of what actually happened.
+  if [ "${FAIL:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "NOTE: FAIL>0 -- preserving WORK_DIR for debugging: ${WORK_DIR}" >&2
+    if [ -f "${WORK_DIR}/watchdog.err" ]; then
+      echo "--- ${WORK_DIR}/watchdog.err (full contents) ---" >&2
+      cat "${WORK_DIR}/watchdog.err" >&2
+    fi
+  else
+    rm -rf "${WORK_DIR}"
+  fi
+}
+trap _cleanup_work_dir EXIT
 
 HERMES_HOME="${WORK_DIR}/hermes-home"
 mkdir -p "${HERMES_HOME}"

--- a/tests/hermes-phaseB-gate.sh
+++ b/tests/hermes-phaseB-gate.sh
@@ -252,16 +252,25 @@ PYEOF
         "manifest ${MANIFEST_FILE} did not reach status=failed after up to 6 watchdog.sh passes; see ${WORK_DIR}/watchdog.err"
     fi
 
+    # notify_dispatch/notify_slack in watchdog.sh logs one of four distinct
+    # outcomes, all of which prove the notify path was actually invoked
+    # (the gate's fake C_PHASEB_GATE Slack channel realistically only ever
+    # hits the "no token" or "rejected" cases, never real success):
+    #   1. SLACK_BOT_TOKEN unset         -> "skipping notify for channel ..."
+    #   2. curl/network error           -> "Slack notify failed for channel ..."
+    #   3. Slack API-level rejection    -> "Slack notify rejected for channel ..."
+    #   4. success                      -> "notified (status=failed ..."
+    NOTIFY_PATTERN='skipping notify for channel|Slack notify failed for channel|Slack notify rejected for channel|notified \(status=failed'
     echo "- ac2b_notify_path_exercised"
     if grep -q 'reconciling status to failed (issue #122)' "${WORK_DIR}/watchdog.err" &&
-      grep -q -e 'skipping notify for channel' -e 'notified (status=failed' "${WORK_DIR}/watchdog.err"; then
+      grep -qE "${NOTIFY_PATTERN}" "${WORK_DIR}/watchdog.err"; then
       pass "ac2b_notify_path_exercised"
     else
       fail "ac2b_notify_path_exercised" \
-        "expected watchdog.err to contain both the 'reconciling status to failed (issue #122)' reconcile line and either a 'skipping notify for channel' or 'notified (status=failed' notify line; see ${WORK_DIR}/watchdog.err"
+        "expected watchdog.err to contain both the 'reconciling status to failed (issue #122)' reconcile line and a notify-path line (skipping/failed/rejected/notified); see ${WORK_DIR}/watchdog.err"
     fi
 
-    if [ "${RECONCILED}" = "true" ] && grep -q -e 'skipping notify for channel' -e 'notified (status=failed' "${WORK_DIR}/watchdog.err"; then
+    if [ "${RECONCILED}" = "true" ] && grep -qE "${NOTIFY_PATTERN}" "${WORK_DIR}/watchdog.err"; then
       echo "  AC-2 RESULT: RECONCILED -- per-job container killed -> watchdog"
       echo "               reconciled job to failed and notify path was"
       echo "               exercised (no auto-retry by design, issue #122)."

--- a/tests/hermes-phaseB-gate.sh
+++ b/tests/hermes-phaseB-gate.sh
@@ -3,9 +3,9 @@
 # Real (docker + git + claude CLI) go/no-go GATE for the フェーズB execution
 # model decision (S4, AC-2, AC-3):
 #
-#   AC-2: "dispatch コンテナを明示 kill してもジョブが前進し PR が生成される、
-#          または no-go と判定され長寿命 per-job コンテナモデルが確定要件と
-#          して記録される (フェーズB go/no-go ゲート)"
+#   AC-2: per-job コンテナを明示 kill した後、watchdog がコンテナ死を検知して
+#          ジョブを status=failed へ reconcile し、既存 notify 経路で通知する
+#          ことを実機確認する (自動再試行はしない設計決定、issue #122)
 #   AC-3: "per-job `CLAUDE_CONFIG_DIR` を host 非root から `claude agents` で
 #          読み取れることを実機確認できる (フェーズB)"
 #
@@ -37,8 +37,6 @@ HERMES_AGENT_ROOT="${HERMES_AGENT_ROOT:-${HOME}/.hermes/hermes-agent}"
 VENV_PYTHON="${HERMES_AGENT_ROOT}/venv/bin/python"
 TARGET_REPO="${1:-it-all-playpark/dotfiles}"
 KILL_DELAY_SECONDS="${KILL_DELAY_SECONDS:-5}"
-POLL_TIMEOUT_SECONDS="${POLL_TIMEOUT_SECONDS:-120}"
-POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
 
 PASS=0
 FAIL=0
@@ -101,7 +99,8 @@ platforms:
 EOF
 
 # ---------------------------------------------------------------------------
-# AC-2: dispatch container を明示 kill -> ジョブ前進 (PR生成) するか観測
+# AC-2: per-job container を明示 kill -> watchdog が failed へ reconcile し
+#       通知経路を実行するか観測 (issue #122)
 # ---------------------------------------------------------------------------
 JOB_ID=""
 WORKSPACE_HOST_DIR=""
@@ -174,36 +173,57 @@ PYEOF
         "docker kill ${CONTAINER_NAME} failed (container may have already exited)"
     fi
 
-    echo "- ac2_job_progress_after_kill (poll up to ${POLL_TIMEOUT_SECONDS}s)"
-    ELAPSED=0
-    PROGRESSED=false
-    while [ "${ELAPSED}" -lt "${POLL_TIMEOUT_SECONDS}" ]; do
-      MANIFEST_FILE="${HERMES_HOME}/jobs/${JOB_ID}.json"
-      if [ -f "${MANIFEST_FILE}" ] && jq -e '.status == "done"' "${MANIFEST_FILE}" >/dev/null 2>&1; then
-        PROGRESSED=true
-        break
-      fi
-      if gh pr list --repo "${TARGET_REPO}" --search "hermes-phaseB-gate ${JOB_ID}" --json number \
-        --jq 'length > 0' 2>/dev/null | grep -q true; then
-        PROGRESSED=true
-        break
-      fi
-      sleep "${POLL_INTERVAL_SECONDS}"
-      ELAPSED=$((ELAPSED + POLL_INTERVAL_SECONDS))
-    done
+    MANIFEST_FILE="${HERMES_HOME}/jobs/${JOB_ID}.json"
 
-    if [ "${PROGRESSED}" = "true" ]; then
-      pass "ac2_job_progress_after_kill"
-      echo "  AC-2 RESULT: GO -- job progressed (manifest done / PR found) after"
-      echo "               the dispatch container was explicitly killed."
-      echo "               -> record 長寿命 per-job container モデル as confirmed"
-      echo "                  required design in the decision-log."
+    echo "- ac2b_watchdog_reconciles_killed_container_to_failed (up to 6 watchdog passes)"
+    RECONCILED=false
+    for _ in 1 2; do
+      HERMES_HOME="${HERMES_HOME}" HERMES_WATCHDOG_SKIP_LOCK=1 \
+        bash "${REPO_ROOT}/hermes/watchdog.sh" 2>>"${WORK_DIR}/watchdog.err" || true
+    done
+    if [ -f "${MANIFEST_FILE}" ] && jq -e '.status == "failed"' "${MANIFEST_FILE}" >/dev/null 2>&1; then
+      RECONCILED=true
     else
-      fail "ac2_job_progress_after_kill" \
-        "no manifest status=done and no matching PR within ${POLL_TIMEOUT_SECONDS}s of killing ${CONTAINER_NAME}"
-      echo "  AC-2 RESULT: NO-GO -- job did not progress after the dispatch"
-      echo "               container was killed within the poll window."
-      echo "               -> record no-go in the decision-log."
+      # HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT default is 2, but real
+      # environments may have claude agents session-state lag or race with
+      # the bg_absent_streak path, so allow up to 6 total passes before
+      # judging.
+      for _ in 3 4 5 6; do
+        sleep 2
+        HERMES_HOME="${HERMES_HOME}" HERMES_WATCHDOG_SKIP_LOCK=1 \
+          bash "${REPO_ROOT}/hermes/watchdog.sh" 2>>"${WORK_DIR}/watchdog.err" || true
+        if [ -f "${MANIFEST_FILE}" ] && jq -e '.status == "failed"' "${MANIFEST_FILE}" >/dev/null 2>&1; then
+          RECONCILED=true
+          break
+        fi
+      done
+    fi
+
+    if [ "${RECONCILED}" = "true" ]; then
+      pass "ac2b_watchdog_reconciles_killed_container_to_failed"
+    else
+      fail "ac2b_watchdog_reconciles_killed_container_to_failed" \
+        "manifest ${MANIFEST_FILE} did not reach status=failed after up to 6 watchdog.sh passes; see ${WORK_DIR}/watchdog.err"
+    fi
+
+    echo "- ac2b_notify_path_exercised"
+    if grep -q 'reconciling status to failed (issue #122)' "${WORK_DIR}/watchdog.err" &&
+      grep -q -e 'skipping notify for channel' -e 'notified (status=failed' "${WORK_DIR}/watchdog.err"; then
+      pass "ac2b_notify_path_exercised"
+    else
+      fail "ac2b_notify_path_exercised" \
+        "expected watchdog.err to contain both the 'reconciling status to failed (issue #122)' reconcile line and either a 'skipping notify for channel' or 'notified (status=failed' notify line; see ${WORK_DIR}/watchdog.err"
+    fi
+
+    if [ "${RECONCILED}" = "true" ] && grep -q -e 'skipping notify for channel' -e 'notified (status=failed' "${WORK_DIR}/watchdog.err"; then
+      echo "  AC-2 RESULT: RECONCILED -- per-job container killed -> watchdog"
+      echo "               reconciled job to failed and notify path was"
+      echo "               exercised (no auto-retry by design, issue #122)."
+    else
+      echo "  AC-2 RESULT: FAIL -- watchdog did not reconcile the killed"
+      echo "               container's job to failed and/or the notify path"
+      echo "               was not exercised within the poll window."
+      echo "               -> record in the decision-log."
     fi
 
     docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true

--- a/tests/hermes-phaseB-gate.sh
+++ b/tests/hermes-phaseB-gate.sh
@@ -154,6 +154,7 @@ PYEOF
 
   if [ -n "${JOB_ID}" ]; then
     CONTAINER_NAME="hermes-claude-${JOB_ID}"
+    MANIFEST_FILE="${HERMES_HOME}/jobs/${JOB_ID}.json"
 
     echo "- ac2_dispatch_container_running_before_kill"
     if docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -q true; then
@@ -182,14 +183,28 @@ PYEOF
           "${CONTAINER_NAME}" 2>&1 || echo "(inspect failed — container may already be --rm'd)"
         echo "--- docker logs (last 100 lines) ---"
         docker logs --tail 100 "${CONTAINER_NAME}" 2>&1 || echo "(logs unavailable)"
+        echo "--- claude agents --json --all (bg session's own reported status) ---"
+        if [ -f "${MANIFEST_FILE}" ]; then
+          BG_JOB_ID="$(jq -r '.bg_job_id // empty' "${MANIFEST_FILE}" 2>/dev/null || true)"
+          CFG_DIR="$(jq -r '.claude_config_host_dir // empty' "${MANIFEST_FILE}" 2>/dev/null || true)"
+          WS_DIR="$(jq -r '.workspace_host_dir // empty' "${MANIFEST_FILE}" 2>/dev/null || true)"
+          if [ -n "${CFG_DIR}" ] && [ -n "${WS_DIR}" ]; then
+            RAW_JSON="$(CLAUDE_CONFIG_DIR="${CFG_DIR}" claude agents --json --all --cwd "${WS_DIR}" 2>&1 || echo '(claude agents invocation failed)')"
+            echo "bg_job_id=${BG_JOB_ID}"
+            echo "matching entry: $(printf '%s' "${RAW_JSON}" | jq -c --arg id "${BG_JOB_ID}" '[.[] | select((.id // .sessionId // .taskId // .job_id) == $id)] | .[0]' 2>/dev/null || echo '(jq parse failed)')"
+            echo "full listing: ${RAW_JSON}"
+          else
+            echo "(manifest missing claude_config_host_dir/workspace_host_dir)"
+          fi
+        else
+          echo "(manifest ${MANIFEST_FILE} not found yet)"
+        fi
       } >"${DIAG_FILE}" 2>&1
       fail "ac2_explicit_kill_of_dispatch_container" \
         "docker kill ${CONTAINER_NAME} failed (container may have already exited); diagnostics: ${DIAG_FILE}"
       echo "  --- container diagnostics (${DIAG_FILE}) ---"
       cat "${DIAG_FILE}" | sed 's/^/    /'
     fi
-
-    MANIFEST_FILE="${HERMES_HOME}/jobs/${JOB_ID}.json"
 
     echo "- ac2b_watchdog_reconciles_killed_container_to_failed (up to 6 watchdog passes)"
     RECONCILED=false

--- a/tests/hermes-phaseB-gate.sh
+++ b/tests/hermes-phaseB-gate.sh
@@ -169,8 +169,24 @@ PYEOF
     if docker kill "${CONTAINER_NAME}" >/dev/null 2>&1; then
       pass "ac2_explicit_kill_of_dispatch_container"
     else
+      # Debug aid (issue #122 follow-up): the container can only fail this
+      # kill by having already exited on its own between the running-check
+      # above and here, which means the underlying claude bg session died/
+      # completed for some reason unrelated to this gate's explicit kill.
+      # Capture its exit state and last output so that reason is diagnosable
+      # instead of silently discarded when WORK_DIR is removed on exit.
+      DIAG_FILE="${WORK_DIR}/container_diag.txt"
+      {
+        echo "--- docker inspect state ---"
+        docker inspect -f 'Status={{.State.Status}} ExitCode={{.State.ExitCode}} Error={{.State.Error}} OOMKilled={{.State.OOMKilled}}' \
+          "${CONTAINER_NAME}" 2>&1 || echo "(inspect failed — container may already be --rm'd)"
+        echo "--- docker logs (last 100 lines) ---"
+        docker logs --tail 100 "${CONTAINER_NAME}" 2>&1 || echo "(logs unavailable)"
+      } >"${DIAG_FILE}" 2>&1
       fail "ac2_explicit_kill_of_dispatch_container" \
-        "docker kill ${CONTAINER_NAME} failed (container may have already exited)"
+        "docker kill ${CONTAINER_NAME} failed (container may have already exited); diagnostics: ${DIAG_FILE}"
+      echo "  --- container diagnostics (${DIAG_FILE}) ---"
+      cat "${DIAG_FILE}" | sed 's/^/    /'
     fi
 
     MANIFEST_FILE="${HERMES_HOME}/jobs/${JOB_ID}.json"


### PR DESCRIPTION
## 概要
Closes #122

hermes watchdog に per-job Docker コンテナの死活検知（AC-2 対応）を実装。`poll_bg_status` が見る bg セッション自体の listing だけでは、per-job コンテナが kill/OOM/デーモン再起動で消滅しても running 判定のまま残ってしまい、`reconcile_job` が永遠に polling し続けてしまう問題を解消する。

## 動機
issue #122 の実測検証（AC-2）で NO-GO と判定された箇所への対応。単体の bg セッション状態だけに依存すると、per-job コンテナが死んでいても watchdog がそれを検知できず、ジョブが `failed` に遷移しないまま滞留し続けるリスクがあった。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `hermes/watchdog.sh` | `poll_container_state` を新設し `docker inspect -f '{{.State.Running}}' <container_id>` の結果を `alive` / `dead` / `unknown` に分類。`reconcile_job` 内で `poll_bg_status` が `running` を返した場合でも `container_id` があればコンテナ自身の死活を追加でクロスチェックし、`dead` が `HERMES_WATCHDOG_CONTAINER_DEAD_CONFIRM_COUNT`（デフォルト2）回連続観測された場合のみ `status` を `failed` に強制する。`docker` 不在／daemon 到達不能時は `unknown` として既存の `container_dead_streak` を変更しない（誤検知防止）。`container_id` が記録されていない旧マニフェストは後方互換のためチェック自体をスキップする |
| `hermes/plugins/claude_runner/tests/test_watchdog_container.py` | `poll_container_state` / `reconcile_job` のコンテナ死活検知パスに対する新規ユニットテスト（alive でのストリークリセット、no such object での dead 確定、Running=false の dead 観測、daemon 到達不能時の unknown 扱いでストリーク不変、container_id 無しマニフェストのスキップ、bg セッション completed 優先、等） |
| `claudedocs/hermes-phaseB-execution-model-decision.md` | AC-2 の実測結果と、watchdog が自動でコンテナ再起動／ジョブ再ディスパッチを行わない運用上の設計判断を記録 |
| `tests/hermes-claude-runner.test.sh` | 新規テストファイルを含むよう pytest 実行対象を更新 |
| `tests/hermes-phaseB-gate.sh` | AC-2 の go/no-go ゲート整備（docker daemon 到達不能なシェルでは SKIP 扱いにする等） |

## テスト計画
- [x] `tests/hermes-claude-runner.test.sh` — 54 passed
- [x] `tests/hermes-phaseB-gate.sh` — AC-2 / AC-3 ともに実測 GO（2026-07-23、docker socket 到達可能な host shell で 6 passed / 0 failed。詳細は `claudedocs/hermes-phaseB-execution-model-decision.md` 参照）
