### PR TITLE
docs(hermes): AC-12 Google Chat gating gap の決定を記録（案B・保留）

### DIFF
--- a/claudedocs/hermes-phaseE-googlechat-user-gating-decision.md
+++ b/claudedocs/hermes-phaseE-googlechat-user-gating-decision.md
@@ -93,13 +93,17 @@ route/space 境界の保証は満たすが、「allowlist 外の個人・mention
 
 ## 決定
 
-**要決定（人間判断へ escalate、決定保留）**
+**決定: 案B（保留、追跡先 issue: [#120](https://github.com/it-all-playpark/dotfiles/issues/120)）**
 
-- planner/implementer は本 gap の受容可否（案Aで受容するか、案Bで production bind を保留するか）
-  を代行して決定しない。evaluator の `escalate_reason: accountability` の要請どおり、これは
-  人間が選ぶべき決定点として提示するに留める。
-- 決定後の手順: 人間が案A（受容）または案B（保留/gateway adapter 改修待ち）のいずれかを選んだ
-  時点で、本ドキュメントの本節を「決定: 案A（受容）」または「決定: 案B（保留、追跡先 issue: …）」
-  に書き換え、`hermes/README.md` の AC-12 チェックリスト（Google Chat 項）から本ファイルへの
-  参照を維持したまま、選択した案に応じた運用注記（案A: space membership 管理の運用手順明記 /
-  案B: production bind 保留の明記または追跡 issue リンク）を追記すること。
+- Google Chat の production bind（`GOOGLE_CHAT_WEBHOOK_SECRET` の設定・`repo_bindings.yaml` の
+  `platforms.google_chat` binding の有効化）は、gateway adapter 側
+  （`~/.hermes/hermes-agent/gateway/platforms/webhook.py` の送信者識別情報を用いた per-user
+  gating 追加、または専用 `google_chat.py` adapter の新設。詳細は #120）が完了するまで保留する。
+- 理由: (1) Google Chat は現時点で未有効化（opt-in構成、`.env` に secret 未投入）であり保留の
+  実質コストはゼロ、(2) C7（資格情報 blast radius、`hermes-c7-blast-radius-decisions.md`）が
+  未解決のまま残っている状態で、さらに「入口側の個人認可なし」というリスクを重ねて受容する
+  合理性がないため。
+- 初回展開は Discord から行う（Discord は `DISCORD_ALLOWED_USERS`/`DISCORD_ALLOWED_ROLES` +
+  `require_mention: true` により per-user 粒度で AC-12 を満たす）。
+- #120 の実装が完了し AC-12 が Google Chat 側でも per-user 粒度で充足された時点で、本節を
+  再度更新し production bind を解禁する。

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -399,10 +399,11 @@ Google Chat 用の native adapter は存在しない (`gateway/platforms/` に `
    > 管理外のため、`hermes/config.yaml`/`hermes/repo_bindings.yaml` の config 変更だけでは
    > per-user gating を追加できない。したがって **Google Chat は AC-12 (allowlist 外ユーザー/
    > mention なしの dispatch 拒否) を per-user 粒度では config だけで満たさない**。
-   > 受容可否は人間判断への escalate 事項として
+   > **決定: 案B（保留、追跡先 [issue #120](https://github.com/it-all-playpark/dotfiles/issues/120)）**。
+   > gateway adapter 側の per-user gating 追加が完了するまで、Google Chat の production bind
+   > （`GOOGLE_CHAT_WEBHOOK_SECRET` の設定・下記 binding の有効化）は行わないこと。詳細は
    > [`claudedocs/hermes-phaseE-googlechat-user-gating-decision.md`](../claudedocs/hermes-phaseE-googlechat-user-gating-decision.md)
-   > (要決定・決定保留) に記録している。決定前に Google Chat を production bind する場合は
-   > このリスクを踏まえた上で行うこと。
+   > を参照。初回展開は per-user gating が機能する Discord から行う。
 
 ### 重複配送 (dedupe) は platform adapter 層の責務 (AC-13)
 
@@ -435,20 +436,17 @@ Discord / Google Chat は保証レベルが異なる (per-user allowlist vs rout
   - `require_mention: true` の bind channel に bot を mention せず通常メッセージを送り、
     dispatch_job が呼ばれないことを確認する
 
-#### [Google Chat・route/space 境界のみ] AC-12
+#### [Google Chat・保留中 (issue #120)] AC-12
 
-> per-user 粒度の allowlist・mention gating は存在しない。以下は「未認証源 (誤った secret)
-> の遮断」の確認であり、「allowlist 外の個人・mention なしの拒否」ではない。受容可否は
+> **決定: 案B（保留）**。gateway adapter 側の per-user gating 追加が完了する（[issue #120](https://github.com/it-all-playpark/dotfiles/issues/120)）まで、
+> Google Chat の production bind は行わない。以下のチェックリストは #120 完了後、per-user
+> gating が実装されてから実施する。詳細は
 > [`claudedocs/hermes-phaseE-googlechat-user-gating-decision.md`](../claudedocs/hermes-phaseE-googlechat-user-gating-decision.md)
-> の決定 (要決定・決定保留) に依存する。
+> を参照。
 
-- [ ] **誤った/未知の secret を伴う POST が拒否されること (route/space 境界の確認、per-user
-      allowlist の確認ではない)**
-  - `GOOGLE_CHAT_WEBHOOK_SECRET` を知らない送信元、または誤った secret で webhook route に
-    POST し、`webhook.py` の signature 検証で拒否され dispatch されないことを確認する
-  - **per-user 制御の確認ではない**: bound space に在籍する正規メンバーが secret を伴って
-    送信した場合の per-user 絞り込み・mention gating は E3 決定 (上記リンク) が案A/案B の
-    どちらかに定まるまで検証対象外
+- [ ] **(#120 完了後) allowlist 外ユーザ・mention なしメッセージが dispatch されないこと**
+  - 未認証源 (誤った secret) の遮断だけでなく、per-user allowlist・mention 相当の gating が
+    機能することを実機確認する
 
 #### [dedupe・AC-13] 全 platform 共通
 


### PR DESCRIPTION
## 概要
Refs #120

issue #116 / PR #117 で escalate されていた AC-12 の Google Chat per-user gating gap について、人間判断の結果を decision-log と README に記録する。

## 決定
**案B（保留）**: gateway adapter（`~/.hermes/hermes-agent/gateway/platforms/webhook.py`、サードパーティOSS）側に per-user 送信者検証・mention相当gatingが追加される（#120）まで、Google Chat の production bind（`GOOGLE_CHAT_WEBHOOK_SECRET` 設定・binding有効化）を保留する。

理由:
- Google Chat は現時点で未有効化（opt-in構成）のため保留の実質コストはゼロ
- C7（資格情報 blast radius）が未解決のまま残っている状態で、入口側の個人認可なしというリスクを重ねて受容する合理性がない
- 初回展開は per-user gating が機能する Discord から行う

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `claudedocs/hermes-phaseE-googlechat-user-gating-decision.md` | 「決定」節を「要決定」から「決定: 案B（保留、追跡先 #120）」に更新 |
| `hermes/README.md` | AC-12チェックリスト（Google Chat項）を決定内容に合わせて更新 |

## テスト計画
ドキュメントのみの変更のため実行テストなし。