### PR TITLE
fix(claude-code): git push hookのgit -C等グローバルオプション迂回を修正

### DIFF
--- a/claude-code/container.settings.json
+++ b/claude-code/container.settings.json
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "command": "bash \"$HOME/.claude/hooks/allow-feature-push.sh\"",
-            "if": "Bash(git push*)",
+            "if": "Bash(git*)",
             "statusMessage": "push ブランチチェック中...",
             "timeout": 5,
             "type": "command"

--- a/claude-code/hooks/allow-feature-push.sh
+++ b/claude-code/hooks/allow-feature-push.sh
@@ -38,40 +38,6 @@ if [ "${CMD_TOKENS[0]:-}" != "git" ]; then
   exit 0
 fi
 
-PUSH_IDX=-1
-skip_global_next=0
-for ((i = 1; i < ${#CMD_TOKENS[@]}; i++)); do
-  tok="${CMD_TOKENS[$i]}"
-  if [ "$skip_global_next" = "1" ]; then
-    skip_global_next=0
-    continue
-  fi
-  case "$tok" in
-  -C | -c | --git-dir | --work-tree | --namespace | --exec-path | --config-env | --super-prefix)
-    skip_global_next=1
-    continue
-    ;;
-  --git-dir=* | --work-tree=* | --namespace=* | --exec-path=* | --config-env=* | --super-prefix=*)
-    continue
-    ;;
-  -*)
-    continue
-    ;;
-  push)
-    PUSH_IDX=$i
-    break
-    ;;
-  *)
-    # push 以外のサブコマンド（status/commit/...）→ 対象外
-    exit 0
-    ;;
-  esac
-done
-
-if [ "$PUSH_IDX" -lt 0 ]; then
-  exit 0
-fi
-
 deny() {
   local branch="$1"
   echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"保護/デプロイブランチ ($branch) への push は禁止\"}}"
@@ -99,6 +65,73 @@ is_protected() {
     ;;
   esac
 }
+
+PUSH_IDX=-1
+skip_global_next=0
+skip_location_next=0
+# -C / --git-dir / --work-tree は push 先の解決に使うリポジトリ位置を変える
+# ため、値ごとトークン列を保存しておき、fallback のブランチ解決（後述の
+# git rev-parse 呼び出し）でも同じ位置指定を再現する。これをしないと、
+# `git -C <他リポジトリ> push`（refspec 省略）を hook 実行時の cwd と
+# 異なる cwd から呼んだ場合に、rev-parse が cwd 基準のブランチを返して
+# しまい、-C が指す実際の push 先ブランチと食い違った allow/deny を返す。
+GLOBAL_LOCATION_ARGS=()
+for ((i = 1; i < ${#CMD_TOKENS[@]}; i++)); do
+  tok="${CMD_TOKENS[$i]}"
+  if [ "$skip_location_next" = "1" ]; then
+    skip_location_next=0
+    GLOBAL_LOCATION_ARGS+=("$tok")
+    continue
+  fi
+  if [ "$skip_global_next" = "1" ]; then
+    skip_global_next=0
+    continue
+  fi
+  case "$tok" in
+  -C | --git-dir | --work-tree)
+    GLOBAL_LOCATION_ARGS+=("$tok")
+    skip_location_next=1
+    continue
+    ;;
+  --git-dir=* | --work-tree=*)
+    GLOBAL_LOCATION_ARGS+=("$tok")
+    continue
+    ;;
+  -c | --namespace | --exec-path | --config-env | --super-prefix | --attr-source)
+    skip_global_next=1
+    continue
+    ;;
+  --namespace=* | --exec-path=* | --config-env=* | --attr-source=*)
+    continue
+    ;;
+  -*)
+    continue
+    ;;
+  push)
+    PUSH_IDX=$i
+    break
+    ;;
+  *)
+    # push 以外のサブコマンド（status/commit/...）か、未知の値取り
+    # グローバルオプションの値トークンの可能性がある。後者を前者と
+    # 誤認して無条件 exit 0（fail-open）すると、本スクリプトが未知の
+    # 値取りグローバルオプション（将来の git バージョンで追加される
+    # ものを含む）を素通りさせてしまう（--attr-source が過去にこの
+    # 経路で抜けていた）。残りのトークンに "push" が実在する場合は
+    # 判定を確定できないため ask に倒す。
+    for ((j = i + 1; j < ${#CMD_TOKENS[@]}; j++)); do
+      if [ "${CMD_TOKENS[$j]}" = "push" ]; then
+        ask "未知のグローバルオプションを含む git コマンドのため push 判定を確定できません"
+      fi
+    done
+    exit 0
+    ;;
+  esac
+done
+
+if [ "$PUSH_IDX" -lt 0 ]; then
+  exit 0
+fi
 
 # "push" 以降のトークンを取り出す（値を取るフラグはその値ごとスキップ）。
 # 文字列の prefix 除去ではなく、上のループで確定した PUSH_IDX から配列
@@ -146,8 +179,11 @@ if [ "${#ARGS[@]}" -ge 2 ]; then
 fi
 
 if [ "${#REFSPECS[@]}" -eq 0 ]; then
-  # refspec に宛先ブランチが明示されない → 現在ブランチを fallback 宛先とする
-  DEST_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  # refspec に宛先ブランチが明示されない → 現在ブランチを fallback 宛先とする。
+  # -C / --git-dir / --work-tree が指定されていた場合は GLOBAL_LOCATION_ARGS
+  # 経由で同じ位置指定を rev-parse にも渡し、hook 実行時の cwd ではなく
+  # 実際の push 対象リポジトリのブランチを解決する。
+  DEST_BRANCH=$(git "${GLOBAL_LOCATION_ARGS[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null)
   if [ -z "$DEST_BRANCH" ] || [ "$DEST_BRANCH" = "HEAD" ]; then
     ask "push 宛先ブランチを検出できません"
   fi
@@ -176,8 +212,9 @@ for REFSPEC in "${REFSPECS[@]}"; do
   # 残る。is_protected は具体的なブランチ名しか知らないため一致せず allow
   # してしまう（main checkout 中の "git push origin HEAD" が push 先 main
   # なのに通ってしまうケース）— 実ブランチへ解決してから判定する。
+  # ここも GLOBAL_LOCATION_ARGS（-C 等）を反映して解決する。
   if [ "$DEST_BRANCH" = "HEAD" ] || [ "$DEST_BRANCH" = "@" ]; then
-    RESOLVED_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    RESOLVED_BRANCH=$(git "${GLOBAL_LOCATION_ARGS[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null)
     if [ -z "$RESOLVED_BRANCH" ] || [ "$RESOLVED_BRANCH" = "HEAD" ]; then
       ask "push 宛先ブランチを検出できません"
     fi

--- a/claude-code/hooks/allow-feature-push.sh
+++ b/claude-code/hooks/allow-feature-push.sh
@@ -112,18 +112,36 @@ for ((i = 1; i < ${#CMD_TOKENS[@]}; i++)); do
     break
     ;;
   *)
-    # push 以外のサブコマンド（status/commit/...）か、未知の値取り
-    # グローバルオプションの値トークンの可能性がある。後者を前者と
-    # 誤認して無条件 exit 0（fail-open）すると、本スクリプトが未知の
-    # 値取りグローバルオプション（将来の git バージョンで追加される
-    # ものを含む）を素通りさせてしまう（--attr-source が過去にこの
-    # 経路で抜けていた）。残りのトークンに "push" が実在する場合は
+    # push 以外のサブコマンド（status/commit/stash/log/help/...）か、未知の
+    # 値取りグローバルオプションの値トークンの可能性がある。
+    #
+    # 直前トークン（CMD_TOKENS[i-1]）が非オプション（"git" 直後、または
+    # 既知グローバルオプションの値を消費済みの後）であれば、このトークン
+    # 自体が実サブコマンドとして確定する（例: `git stash push` の
+    # "stash"、`git commit -m push` の "commit"、`git log --grep push` の
+    # "log"、`git help push` の "help"）。この場合、後続に literal な
+    # "push" が現れても、それは確定済みサブコマンドへの引数（stash の
+    # サブコマンド名／コミットメッセージ／grep パターン等）であり
+    # git push ではないため、ask に倒さず即 exit 0 する。
+    #
+    # 一方、直前トークンが '-' で始まる未知オプション（上の -*) 分岐で
+    # 値を消費されずに通過したもの）である場合のみ、このトークンは
+    # そのオプションの値なのか実サブコマンドなのか区別できない。誤認して
+    # 無条件 exit 0（fail-open）すると、本スクリプトが未知の値取り
+    # グローバルオプション（将来の git バージョンで追加されるものを含む）
+    # を素通りさせてしまう（--attr-source が過去にこの経路で抜けていた）。
+    # この曖昧なケースに限り、残りのトークンに "push" が実在する場合は
     # 判定を確定できないため ask に倒す。
-    for ((j = i + 1; j < ${#CMD_TOKENS[@]}; j++)); do
-      if [ "${CMD_TOKENS[$j]}" = "push" ]; then
-        ask "未知のグローバルオプションを含む git コマンドのため push 判定を確定できません"
-      fi
-    done
+    prev_tok="${CMD_TOKENS[$((i - 1))]}"
+    case "$prev_tok" in
+    -*)
+      for ((j = i + 1; j < ${#CMD_TOKENS[@]}; j++)); do
+        if [ "${CMD_TOKENS[$j]}" = "push" ]; then
+          ask "未知のグローバルオプションを含む git コマンドのため push 判定を確定できません"
+        fi
+      done
+      ;;
+    esac
     exit 0
     ;;
   esac

--- a/claude-code/hooks/allow-feature-push.sh
+++ b/claude-code/hooks/allow-feature-push.sh
@@ -26,11 +26,51 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # Bash allow により保護ブランチ push が deny されず passthrough してしまう
 # ため、read -ra でトークン化してから単一スペース区切りに再結合して判定する。
 read -ra CMD_TOKENS <<<"$CMD"
-NORMALIZED_CMD="${CMD_TOKENS[*]}"
-case "$NORMALIZED_CMD" in
-"git push"*) ;;
-*) exit 0 ;;
-esac
+
+# "git push" という文字列の前方一致だけでは、git と push の間にグローバル
+# オプション（-C <dir> / -c <name>=<value> / --git-dir=<path> 等）が挟まる
+# コマンド（例: `git -C /workspace/jobs/x push origin main`）を素通りさせて
+# しまう（コマンド全体の先頭トークン列が "git" "push" と連続しないため）。
+# トークン列を先頭から辿り、値を取るグローバルオプションはその値ごと
+# スキップして、最初の非オプショントークンが実際に push サブコマンドか
+# どうかで判定する。
+if [ "${CMD_TOKENS[0]:-}" != "git" ]; then
+  exit 0
+fi
+
+PUSH_IDX=-1
+skip_global_next=0
+for ((i = 1; i < ${#CMD_TOKENS[@]}; i++)); do
+  tok="${CMD_TOKENS[$i]}"
+  if [ "$skip_global_next" = "1" ]; then
+    skip_global_next=0
+    continue
+  fi
+  case "$tok" in
+  -C | -c | --git-dir | --work-tree | --namespace | --exec-path | --config-env | --super-prefix)
+    skip_global_next=1
+    continue
+    ;;
+  --git-dir=* | --work-tree=* | --namespace=* | --exec-path=* | --config-env=* | --super-prefix=*)
+    continue
+    ;;
+  -*)
+    continue
+    ;;
+  push)
+    PUSH_IDX=$i
+    break
+    ;;
+  *)
+    # push 以外のサブコマンド（status/commit/...）→ 対象外
+    exit 0
+    ;;
+  esac
+done
+
+if [ "$PUSH_IDX" -lt 0 ]; then
+  exit 0
+fi
 
 deny() {
   local branch="$1"
@@ -60,12 +100,11 @@ is_protected() {
   esac
 }
 
-# "git push" 以降のトークンを取り出す（値を取るフラグはその値ごとスキップ）。
-# 元の $CMD ではなく正規化済み NORMALIZED_CMD から剥がす — 元の $CMD のまま
-# だと連続空白のケースで "git push" prefix が一致せず REST が丸ごと残り、
-# 後続の TOKENS/ARGS 抽出（remote 名/refspec の位置）がずれてしまうため。
-REST="${NORMALIZED_CMD#git push}"
-read -ra TOKENS <<<"$REST"
+# "push" 以降のトークンを取り出す（値を取るフラグはその値ごとスキップ）。
+# 文字列の prefix 除去ではなく、上のループで確定した PUSH_IDX から配列
+# スライスする — グローバルオプション分だけ位置がずれるため、固定長の
+# "git push" prefix 除去では対応できない。
+TOKENS=("${CMD_TOKENS[@]:$((PUSH_IDX + 1))}")
 
 ARGS=()
 HAS_ALL_OR_MIRROR=0

--- a/claude-code/hooks/allow-feature-push.test.sh
+++ b/claude-code/hooks/allow-feature-push.test.sh
@@ -138,11 +138,29 @@ run_case "git --git-dir=<path> push origin main" "git --git-dir=$SCRIPT_DIR/.git
 run_case "git -c user.name=x push origin main" "git -c user.name=x push origin main" "deny"
 run_case "git -c user.name=x -C <dir> push origin main (combined globals)" "git -c user.name=x -C $SCRIPT_DIR push origin main" "deny"
 run_case "git -C <dir> status (non-push subcommand stays noop)" "git -C $SCRIPT_DIR status" "noop"
-# -C と hook 実行時の cwd(workdir 引数)を同じリポジトリに揃えたケース。
-# -C が指すリポジトリと cwd が異なる場合の fallback ブランチ解決までは
-# 対応しない(現状の実装は git rev-parse を常に cwd 基準で呼ぶ)。
+# -C と hook 実行時の cwd(workdir 引数)を同じリポジトリに揃えたケース(sanity)。
 run_case "git -C <dir> push (bare, fallback) on main repo" "git -C $TMP_MAIN_REPO push" "deny" "$TMP_MAIN_REPO"
 run_case "git -C <dir> push (bare, fallback) on feature repo" "git -C $TMP_FEATURE_REPO push" "allow" "$TMP_FEATURE_REPO"
+
+echo "[-C destination differs from hook cwd — fallback must resolve via -C, not cwd]"
+# -C が指すリポジトリと hook 実行時の cwd が異なるケース。fallback のブランチ
+# 解決は cwd ではなく -C の指すリポジトリを基準にしなければならない
+# (cwd 基準のままだと、main への push を feature ブランチとして誤って
+# allow したり、逆に feature ブランチへの push を main として誤って
+# deny したりする)。
+run_case "git -C <main repo> push (bare) from feature repo cwd -> resolves via -C to main -> deny" "git -C $TMP_MAIN_REPO push" "deny" "$TMP_FEATURE_REPO"
+run_case "git -C <feature repo> push (bare) from main repo cwd -> resolves via -C to feature/x -> allow" "git -C $TMP_FEATURE_REPO push" "allow" "$TMP_MAIN_REPO"
+run_case "git -C <main repo> push origin HEAD from feature repo cwd -> resolves via -C to main -> deny" "git -C $TMP_MAIN_REPO push origin HEAD" "deny" "$TMP_FEATURE_REPO"
+run_case "git -C <feature repo> push origin HEAD from main repo cwd -> resolves via -C to feature/x -> allow" "git -C $TMP_FEATURE_REPO push origin HEAD" "allow" "$TMP_MAIN_REPO"
+
+echo "[--attr-source global option (git 2.40+) — must still be detected as push, not fail-open]"
+run_case "git --attr-source HEAD push origin main" "git --attr-source HEAD push origin main" "deny"
+run_case "git --attr-source=HEAD push origin main" "git --attr-source=HEAD push origin main" "deny"
+run_case "git --attr-source HEAD push origin feature/x" "git --attr-source HEAD push origin feature/x" "allow"
+
+echo "[Unknown/unrecognized global option before push — fail-closed to ask, not silent allow]"
+run_case "git --totally-unknown-option value push origin main" "git --totally-unknown-option value push origin main" "ask"
+run_case "git --totally-unknown-option value status (non-push stays noop)" "git --totally-unknown-option value status" "noop"
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/claude-code/hooks/allow-feature-push.test.sh
+++ b/claude-code/hooks/allow-feature-push.test.sh
@@ -162,6 +162,13 @@ echo "[Unknown/unrecognized global option before push — fail-closed to ask, no
 run_case "git --totally-unknown-option value push origin main" "git --totally-unknown-option value push origin main" "ask"
 run_case "git --totally-unknown-option value status (non-push stays noop)" "git --totally-unknown-option value status" "noop"
 
+echo "[Confirmed subcommand (non-option token right after git/known-global-value) — literal later \"push\" token must NOT trigger ask (regression for PR #129 review)]"
+run_case "git stash push (subcommand confirmed, not global-push)" 'git stash push' "noop"
+run_case "git stash push -m wip (subcommand confirmed, not global-push)" 'git stash push -m wip' "noop"
+run_case "git log --grep push (subcommand confirmed, not global-push)" 'git log --grep push' "noop"
+run_case "git commit -m push (subcommand confirmed, not global-push)" 'git commit -m push' "noop"
+run_case "git help push (subcommand confirmed, not global-push)" 'git help push' "noop"
+
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
 if ((FAIL > 0)); then

--- a/claude-code/hooks/allow-feature-push.test.sh
+++ b/claude-code/hooks/allow-feature-push.test.sh
@@ -131,6 +131,19 @@ echo "[Non-push commands → no hook output]"
 run_case "git status" 'git status' "noop"
 run_case "git push-something (not a real push)" 'echo not-a-push' "noop"
 
+echo "[Global option bypass attempts (-C / --git-dir / -c) — must still be detected as push]"
+run_case "git -C <dir> push origin main" "git -C $SCRIPT_DIR push origin main" "deny"
+run_case "git -C <dir> push origin feature/x" "git -C $SCRIPT_DIR push origin feature/x" "allow"
+run_case "git --git-dir=<path> push origin main" "git --git-dir=$SCRIPT_DIR/.git push origin main" "deny"
+run_case "git -c user.name=x push origin main" "git -c user.name=x push origin main" "deny"
+run_case "git -c user.name=x -C <dir> push origin main (combined globals)" "git -c user.name=x -C $SCRIPT_DIR push origin main" "deny"
+run_case "git -C <dir> status (non-push subcommand stays noop)" "git -C $SCRIPT_DIR status" "noop"
+# -C と hook 実行時の cwd(workdir 引数)を同じリポジトリに揃えたケース。
+# -C が指すリポジトリと cwd が異なる場合の fallback ブランチ解決までは
+# 対応しない(現状の実装は git rev-parse を常に cwd 基準で呼ぶ)。
+run_case "git -C <dir> push (bare, fallback) on main repo" "git -C $TMP_MAIN_REPO push" "deny" "$TMP_MAIN_REPO"
+run_case "git -C <dir> push (bare, fallback) on feature repo" "git -C $TMP_FEATURE_REPO push" "allow" "$TMP_FEATURE_REPO"
+
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
 if ((FAIL > 0)); then

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -125,7 +125,7 @@
         "hooks": [
           {
             "command": "bash \"$HOME/.claude/hooks/allow-feature-push.sh\"",
-            "if": "Bash(git push*)",
+            "if": "Bash(git*)",
             "statusMessage": "push ブランチチェック中...",
             "timeout": 5,
             "type": "command"


### PR DESCRIPTION
## Summary
- `claude-code/hooks/allow-feature-push.sh` の push 系コマンド判定が `"git push"*` という文字列前方一致だったため、`git` と `push` の間にグローバルオプション(`-C <dir>` / `--git-dir=<path>` / `-c <name>=<value>` 等)が挟まるコマンドを検出できず素通りしていた不具合を修正
- 背景: hermes の ChatOps dispatch container 経由での bind repo bind 見直し作業中、fable subagent によるリスク分析で `git -C /workspace/jobs/x push origin main` がこの hook を素通りすることを実証(`git push origin main` は deny されるが、`-C` を挟むだけで判定なしになっていた)
- `container.settings.json` の `permissions.deny`(`Bash(git push origin HEAD:refs/heads/main)` 等)も同じ文字列マッチの仕組みのため同様に迂回可能。この PR では hook 側の検出ロジックを直しているが、根本原因(サーバー側で強制される branch protection が無いと迂回不能な防御層が無い)自体は別課題として残る

## 変更内容
- トークン列を先頭から辿り、値を取るグローバルオプション(`-C`/`-c`/`--git-dir`/`--work-tree`/`--namespace`/`--exec-path`/`--config-env`/`--super-prefix`)をその値ごとスキップしてから、最初の非オプショントークンが実際に `push` サブコマンドかどうかで判定するよう変更
- `push` 以降の引数抽出を、文字列 prefix 除去(`"${NORMALIZED_CMD#git push}"`)ではなく、確定した `push` のトークン位置からの配列スライスに変更(グローバルオプション分だけ位置がずれるため)
- 回帰テストを追加: `git -C <dir> push origin main`(deny)、`git -C <dir> push origin feature/x`(allow)、`git --git-dir=<path> push origin main`(deny)、`git -c user.name=x push origin main`(deny)、複数グローバルオプションの組み合わせ、`git -C <dir> status`(push以外は引き続きnoop)、`-C` + fallback(refspec省略)の組み合わせ

## Test plan
- [x] `bash claude-code/hooks/allow-feature-push.test.sh` → 既存39件 + 新規8件 = 計47件 PASS
- [x] `bash -n claude-code/hooks/allow-feature-push.sh` construct チェック OK
- [ ] shellcheck(このマシンに未インストールのため未実施)