### PR TITLE
feat: deskflow のサーバ設定を dotfiles 管理下に置く

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -81,6 +81,12 @@ in
       ".myclirc.local.template".source = ./file/.myclirc.local.template;
       ".config/git/config.local.template".source = ./file/git/config.local.template;
       ".config/fish/config.fish.local.template".source = ./file/fish/config.fish.local.template;
+      # Deskflow (ソフトウェアKVM) のサーバ設定。GUI の Server タブで「外部設定ファイル
+      # を使う」を有効にし、このパスを指定する。外部設定が有効な間 Deskflow はこのファイル
+      # を読むだけで書き戻さない (CoreProcess::persistServerConfig) ため、home-manager の
+      # read-only symlink で問題ない。デフォルトの ~/Library/Deskflow/ 側は書き込み可能の
+      # まま残すので、外部設定を切っても GUI が壊れない。
+      ".config/deskflow/deskflow-server.conf".source = ./file/deskflow/deskflow-server.conf;
       ".config/nvim" = {
         source = ./file/nvim;
         recursive = true;

--- a/home-manager/home/file/deskflow/README.md
+++ b/home-manager/home/file/deskflow/README.md
@@ -1,0 +1,67 @@
+# Deskflow server config
+
+Mac 間でキーボード・マウスを共有する Deskflow のサーバ設定 (`deskflow-server.conf`)。
+アプリ本体は `darwin/default.nix` の Homebrew cask で導入している。
+
+配置先は `~/.config/deskflow/deskflow-server.conf`（home-manager の read-only symlink）。
+
+## 初回セットアップ（手動、1回だけ）
+
+1. Deskflow の GUI → Server タブ → **Use external configuration file** を有効化
+2. パスに `~/.config/deskflow/deskflow-server.conf` を指定
+3. サーバを再起動
+
+`~/Library/Deskflow/Deskflow.conf` の `[server]` セクションに以下が入れば成功:
+
+```ini
+externalConfig=true
+externalConfigFile=/Users/<user>/.config/deskflow/deskflow-server.conf
+```
+
+デフォルトの `~/Library/Deskflow/deskflow-server.conf` は書き込み可能なまま残してある。
+外部設定を無効に戻しても GUI が書き込みに失敗しない。
+
+## なぜ read-only symlink で平気か
+
+`CoreProcess::persistServerConfig()` は外部設定が有効なとき、パスと readable 判定を
+返すだけでファイルを書かない。内部設定モードのときだけデフォルトパスを
+`WriteOnly | Truncate` で開いて書き出す。GUI がこのファイルへ書くのは
+「Save server configuration as...」をユーザーが明示的に実行したときのみ。
+
+## ホットキーの修飾キー名が反転している件
+
+macOS サーバーでは `OSXKeyState::mapDeskflowHotKeyToMac()` の変換が直感と食い違う:
+
+| conf の名前 | 実際の物理キー |
+| --- | --- |
+| `Shift` | ⇧ |
+| `Control` | ⌃ |
+| `Alt` | **⌘**（⌥ ではない） |
+| `Super` | **⌥**（⌘ ではない） |
+| `Meta` | **黙って捨てられる** |
+
+ホットキーの照合は `InputFilter::KeystrokeCondition::match` が登録済みホットキー ID
+だけで行うので、実際に効く物理キーはこの変換が全てを決める。
+
+GUI のホットキー録音は Qt の macOS ctrl/meta swap により物理 ⌃ を `Meta`、物理 ⌘ を
+`Control` と書き出すため、**GUI で作ったホットキーは必ず死ぬ**
+(upstream: deskflow/deskflow#7972)。この conf を手で編集すること。
+
+## 現在のホットキー
+
+| 物理キー | 動作 |
+| --- | --- |
+| ⌘⌃T | MacBook Pro (`OMBP-M3P.local`) へ切替 |
+| ⌘⌃S | Mac Studio (`USERnoMac-Studio.local`) へ切替 |
+
+大西配列の t=左 / s=右 に合わせてある。⌘ を含む組み合わせは ghostty が消費して
+zellij・nvim・fish には届かないので、`Alt+t/n/r/s` や `Ctrl+Alt+t/n/r/s` を使う
+zellij とは衝突しない。macOS システムホットキー（⌘⌃ の英字は ⌃⌘D のみ）、
+ghostty デフォルト（⌘⌃ は `f` `=` 矢印 `⇧J`）、Raycast（⌘Space）とも未使用を確認済み。
+
+## 編集時の注意
+
+- **非 ASCII 文字を書かない**。`ConfigReadContext::readLine()` の `isgraph` 検査で
+  parse エラーになる。コメントも英語で書くこと
+- `#` 以降は行コメントとして除去される
+- `switchToScreen()` の画面名は `section: screens` の宣言と一致させる

--- a/home-manager/home/file/deskflow/deskflow-server.conf
+++ b/home-manager/home/file/deskflow/deskflow-server.conf
@@ -1,0 +1,60 @@
+section: screens
+	OMBP-M3P.local:
+		halfDuplexCapsLock = false
+		halfDuplexNumLock = false
+		halfDuplexScrollLock = false
+		xtestIsXineramaUnaware = false
+		switchCorners = none
+		switchCornerSize = 0
+	USERnoMac-Studio.local:
+		halfDuplexCapsLock = false
+		halfDuplexNumLock = false
+		halfDuplexScrollLock = false
+		xtestIsXineramaUnaware = false
+		switchCorners = none
+		switchCornerSize = 0
+end
+
+section: aliases
+end
+
+section: links
+	OMBP-M3P.local:
+		right = USERnoMac-Studio.local
+	USERnoMac-Studio.local:
+		left = OMBP-M3P.local
+end
+
+section: options
+	protocol = barrier
+	relativeMouseMoves = false
+	win32KeepForeground = false
+	defaultLockToScreenState = false
+	disableLockToScreen = false
+	clipboardSharing = true
+	clipboardSharingSize = 3072
+	switchCorners = none
+	switchCornerSize = 0
+	# Hotkeys: physical Command+Control+T / +S (Mac Studio is the server).
+	#
+	# IMPORTANT - on a macOS server the modifier NAMES below do not mean what
+	# they look like. OSXKeyState::mapDeskflowHotKeyToMac() converts them as:
+	#   Shift   -> Shift
+	#   Control -> Control
+	#   Alt     -> Command   (NOT Option)
+	#   Super   -> Option    (NOT Command)
+	#   Meta    -> dropped silently (a hotkey containing Meta can never fire)
+	# The Deskflow GUI hotkey recorder writes "Meta"/"Control" for the physical
+	# Control/Command keys, which is why GUI-recorded hotkeys are dead here.
+	# Keep editing this file by hand; do not turn off externalConfig.
+	#
+	# Two modifiers are enough because Command never reaches the terminal stack:
+	# zellij (Alt+t/n/r/s, Ctrl+Alt+t/n/r/s), nvim (<C-*>) and fish only ever see
+	# keys ghostty forwards, and ghostty consumes Command itself.
+	# Verified free for T/S: macOS symbolic hotkeys (only Ctrl+Cmd+D is bound),
+	# ghostty defaults (Ctrl+Cmd is used for f, =, arrows, Shift+J only),
+	# Raycast (Command+Space). Ctrl+Cmd+F/Q/D/Space are the widely used ones and
+	# T/S avoid all of them.
+	keystroke(Alt+Control+t) = switchToScreen(OMBP-M3P.local)
+	keystroke(Alt+Control+s) = switchToScreen(USERnoMac-Studio.local)
+end


### PR DESCRIPTION
## 概要

Deskflow（Mac 間のソフトウェア KVM）のサーバ設定を home-manager 管理に移す。

配置先は `~/.config/deskflow/deskflow-server.conf`。

## なぜ read-only symlink で成立するか

`CoreProcess::persistServerConfig()` は外部設定が有効なとき、パスと readable 判定を返すだけでファイルを書かない。内部設定モードのときだけデフォルトパスを `WriteOnly | Truncate` で開いて書き出す。GUI がこのファイルへ書くのは「Save server configuration as...」をユーザーが明示実行したときのみ（`MainWindow::saveServerConfig`）。

## なぜデフォルトパスではなく `~/.config/deskflow/` か

- `~/Library/Deskflow/deskflow-server.conf` は既存の実ファイルがあり、`backupFileExtension` 未設定のため home-manager activation が "file in the way" で失敗する
- そのパスを read-only symlink にすると、外部設定を無効に戻したとき Deskflow が書き込みに失敗してサーバが起動しなくなる

新規パスに置くことで両方回避できる。

## ホットキー

| 物理キー | 動作 |
| --- | --- |
| ⌘⌃T | MacBook Pro (`OMBP-M3P.local`) へ切替 |
| ⌘⌃S | Mac Studio (`USERnoMac-Studio.local`) へ切替 |

macOS サーバーでは `OSXKeyState::mapDeskflowHotKeyToMac()` の変換が反転している（`Alt`→⌘, `Super`→⌥, `Meta`→破棄）ため、conf 上は `Alt+Control+t/s` と書く必要がある。GUI のホットキー録音は Qt の macOS ctrl/meta swap により物理 ⌃ を `Meta` と書き出すので必ず死ぬ（upstream deskflow/deskflow#7972）。経緯は `home-manager/home/file/deskflow/README.md` に記載。

衝突確認済み: macOS システムホットキー（⌘⌃ の英字は ⌃⌘D のみ）、ghostty デフォルト（⌘⌃ は `f` `=` 矢印 `⇧J`）、Raycast（⌘Space）、zellij / nvim（⌘ は ghostty が消費して届かない）。

## 適用後に必要な手動ステップ（1回だけ）

1. Deskflow GUI → Server タブ → **Use external configuration file** を有効化
2. パスに `~/.config/deskflow/deskflow-server.conf` を指定
3. サーバ再起動

## 検証

- `nix-instantiate --parse home-manager/home/default.nix` → OK
- `nixfmt --check home-manager/home/default.nix` → clean
- conf は非 ASCII なし（`ConfigReadContext::readLine()` の `isgraph` 検査を通る）、`switchToScreen()` の画面名は `section: screens` の宣言と一致

未実施: `nix fmt` / `nix eval` は実行環境の sandbox が `~/.cache/nix` と nix daemon socket を塞いでいるため走らせられていない。CI 側での確認が必要。