### PR TITLE
fix(home-manager): gws の keyring backend を file に固定する

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -68,6 +68,26 @@ in
     ];
     stateVersion = "24.05"; # Please read the comment before changing.
 
+    # 全シェル共通の環境変数。fish / zsh のいずれも home-manager が生成する
+    # hm-session-vars を source するため (~/.config/fish/config.fish および
+    # ~/.zshenv)、ここに 1 度書けば両方のシェルに届く。
+    sessionVariables = {
+      # gws (Google Workspace CLI) は既定で macOS Keychain (keyring backend) に
+      # 資格情報を保存しようとするが、保存段階で
+      #   Platform secure storage failure: User interaction is not allowed.
+      # により失敗することがある。この失敗は OAuth 自体が成功した *後* に起きる
+      # ため「login したのに資格情報が一度も更新されない」状態を作り、失効した
+      # refresh_token を掴み続ける。2026-07-26 の hermes gws 障害
+      # (container 内 gws が invalid_grant で全滅) の原因がこれで、Keychain の
+      # 該当エントリは 2 か月以上更新されていなかった。
+      # file backend を既定にして Keychain を経由させない。
+      #
+      # 注: GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE はここに追加しないこと。
+      # credentials.enc より優先されるため、再 login しても古い認証情報を掴み
+      # 続ける状態になる (hermes の container image でも同じ理由で設定していない)。
+      GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND = "file";
+    };
+
     # 共通パッケージ + CLI tool 群 (host モード)
     # pkgs.flock (discoteq/flock, cross-platform flock(1)) — hermes/watchdog.sh
     # (S5) が多重run排除の flock -xn に使う。BSD/macOS には flock(1) が同梱され


### PR DESCRIPTION
## 背景

2026-07-26、hermes の container 内で `gws` を使う Google Workspace 系の依頼がすべて失敗した。

```
Authentication failed: Failed to get token: Server error: invalid_grant: Bad Request
```

調査の結果、mount も env も正しく、原因は **refresh_token が失効していた**ことだった。問題はその先で、「再認証しても直らない」状態になっていた点にある。

### 根本原因

`gws` は既定で macOS Keychain (keyring backend) に資格情報を保存するが、保存段階でこれが失敗する。

```
OS keyring failed: Platform secure storage failure: User interaction is not allowed.
```

**この失敗は OAuth flow が成功した *後* に起きる。** ブラウザ認証は通り、Google 側には grant が作られるが、ローカルには何も保存されない。利用者からは「ログインできた」ように見えるため、失敗に気づけない。

実際、Keychain の `gws-cli` エントリは `cdat`/`mdat` ともに **2026-05-04 のまま**で、2 か月以上更新されていなかった。その間の `gws auth login` はすべてこの経路で黙って失敗していたことになる。

`GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file` を付けて実行したところ、login は一発で成功した。

```json
{
  "keyring_backend": "file",
  "storage": "encrypted",
  "token_valid": true,
  "user": "yuji.naramoto@playpark.work"
}
```

## 変更内容

`home.sessionVariables` に `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND = "file"` を追加する。

### なぜ `home.sessionVariables` か

fish / zsh のいずれも home-manager が生成する `hm-session-vars` を source しているため、**1 度の宣言で両シェルに届く**。

```
~/.config/fish/config.fish:8   source .../hm-session-vars.fish
~/.zshenv:3                    . ".../hm-session-vars.sh"
```

`programs.fish.shellInit` に書く案もあったが、zsh で `gws auth login` した場合に同じ事故が起きるため採らなかった。

fish の `set -Ux`（universal variable）も検討したが、書き込み先の `~/.config/fish/fish_variables` はバージョン管理外のローカル実ファイルであり、「見えない場所に状態が溜まって気づけない」という今回の障害と同じ構造になるため採らなかった。

### `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` を入れていない理由

このパスは `credentials.enc` **より優先される**。設定すると、再 login して `credentials.enc` が更新されても古いファイルを掴み続ける。今回 hermes の container 側で実際にこれが起きており、同じ理由で container image からも削除した（playpark-llc/hermes#9）。

実測:

| 実行条件 | 使われる資格情報 | 結果 |
|---|---|---|
| `KEYRING_BACKEND=file` のみ | `credentials.enc`（新しい） | 成功 |
| `KEYRING_BACKEND=file` + `CREDENTIALS_FILE=token.json` | `token.json`（古い） | `invalid_grant` |

## トレードオフ

file backend では資格情報が `~/.config/gws/credentials.enc` に置かれ、鍵は同ディレクトリの `.encryption_key` になる。Keychain の ACL による保護は失われ、利用者権限で動くプロセスなら復号できる。

ただし Keychain 経路は実際には保存に失敗しており機能していなかったため、「壊れた強い保護」より「動く弱い保護」を選ぶ判断。

## 検証

- `nix-instantiate --parse home-manager/home/default.nix` → **PARSE OK**
- `sessionVariables` が `home = { ... }` ブロック内に正しくネストされていることを確認
- **`nix fmt` / `nix flake check` は未実行。** 作業環境のサンドボックスが nix daemon socket への接続を許可しないため。インデントは周囲のコードに合わせてあるが、format check が通るかはマージ前に確認をお願いしたい
- 反映には `darwin-rebuild switch` が必要。既存シェルには効かない

🤖 Generated with [Claude Code](https://claude.com/claude-code)