### PR TITLE
feat(claude-code): Stop hook で trust telemetry を journal へ転送する (skills#390 Phase 5 unblock)

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -68,6 +68,9 @@ for f in "${PENDING_DIR}"/*.json; do
   pr_number=""
   ci_wait_seconds=""
   ci_poll_attempts=""
+  trust_run_id=""
+  trust_receipts_json=""
+  trust_surfaceproof_json=""
 
   if ! parsed=$(jq -e '{
     skill: .skill,
@@ -87,7 +90,10 @@ for f in "${PENDING_DIR}"/*.json; do
     iterate_status: .telemetry.iterate_status,
     eval_staleness: .telemetry.eval_staleness,
     ci_wait_seconds: .telemetry.ci_wait_seconds,
-    ci_poll_attempts: .telemetry.ci_poll_attempts
+    ci_poll_attempts: .telemetry.ci_poll_attempts,
+    trust_run_id: .telemetry.trust_run_id,
+    trust_receipts: .telemetry.trust_receipts,
+    trust_surfaceproof: .telemetry.trust_surfaceproof_shadow
   }' "$claimed" 2>/dev/null); then
     # JSON parse error
     mkdir -p "${PENDING_DIR}/malformed"
@@ -125,6 +131,9 @@ for f in "${PENDING_DIR}"/*.json; do
   pr_number=$(echo "$parsed" | jq -r '.pr_number // empty')
   ci_wait_seconds=$(echo "$parsed" | jq -r '.ci_wait_seconds // empty')
   ci_poll_attempts=$(echo "$parsed" | jq -r '.ci_poll_attempts // empty')
+  trust_run_id=$(echo "$parsed" | jq -r '.trust_run_id // empty')
+  trust_receipts_json=$(echo "$parsed" | jq -c '.trust_receipts // empty')
+  trust_surfaceproof_json=$(echo "$parsed" | jq -c '.trust_surfaceproof // empty')
 
   # --- Resolve journal.sh ---
   journal_sh=""
@@ -173,6 +182,44 @@ for f in "${PENDING_DIR}"/*.json; do
   fi
   if [[ -n $ci_poll_attempts && $ci_poll_attempts != "null" ]]; then
     cmd_args+=(--ci-poll-attempts "$ci_poll_attempts")
+  fi
+
+  # --- trust telemetry (epic #390 Phase 5 / issue #413) ---
+  # journal.sh は --trust-receipts / --trust-surfaceproof を closed enum で検証し、契約違反時は
+  # exit 1 する。無検査で転送すると entry 全体が pending へ差し戻され、merge_tier 等の基本
+  # telemetry ごと恒久的に失われる。trust キーは optional な付加情報なので、契約を満たす値だけを
+  # 転送し、満たさない値は drop してログに残す（fail-open — base entry の記録を最優先する）。
+  # 例: SurfaceProof が advisory/blocking へ昇格した run は verdict:null を出すため drop される
+  #     （journal.sh 側 enum の拡張は昇格 PR の責務であり本 hook の責務ではない）。
+  if [[ -n $trust_run_id && $trust_run_id != "null" ]]; then
+    cmd_args+=(--trust-run-id "$trust_run_id")
+  fi
+  if [[ -n $trust_receipts_json && $trust_receipts_json != "null" ]]; then
+    if echo "$trust_receipts_json" | jq -e '
+      type == "array" and length > 0 and all(.[];
+        (.layer // "") as $l | (.mode // "") as $m | (.verdict // "") as $v |
+        (["surfaceproof","evalseal","effectdelta"] | index($l)) != null and
+        (["off","shadow","advisory","blocking"] | index($m)) != null and
+        (["pass","fail","inconclusive"] | index($v)) != null)' >/dev/null 2>&1; then
+      cmd_args+=(--trust-receipts "$trust_receipts_json")
+    else
+      mkdir -p "$(dirname "$LOG_FILE")"
+      printf '%s %s trust-key-dropped: trust_receipts (journal.sh closed-enum 契約を満たさない)\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
+    fi
+  fi
+  if [[ -n $trust_surfaceproof_json && $trust_surfaceproof_json != "null" ]]; then
+    if echo "$trust_surfaceproof_json" | jq -e '
+      type == "object" and
+      ((.mode // "") as $m | (.verdict // "") as $v |
+       (["off","shadow","advisory","blocking"] | index($m)) != null and
+       (["pass","fail","inconclusive"] | index($v)) != null)' >/dev/null 2>&1; then
+      cmd_args+=(--trust-surfaceproof "$trust_surfaceproof_json")
+    else
+      mkdir -p "$(dirname "$LOG_FILE")"
+      printf '%s %s trust-key-dropped: trust_surfaceproof_shadow (journal.sh closed-enum 契約を満たさない)\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
+    fi
   fi
 
   # --- Execute journal.sh ---

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -560,6 +560,225 @@ STUB_EOF
 }
 
 # --------------------------------------------------------------------------
+# Helper: build a handoff whose telemetry carries trust keys
+# Usage: make_trust_handoff <outfile> <stub_path> <trust_json_filter>
+# --------------------------------------------------------------------------
+make_trust_handoff() {
+  local outfile="$1" stub="$2" trust_filter="$3"
+  jq -n --arg js "$stub" '{
+    skill: "dev-flow",
+    outcome: "success",
+    issue: 390,
+    journal_sh: $js,
+    telemetry: {
+      merge_tier: "REVIEW",
+      gate_policy: "llm-major-advisory",
+      danger_hits: [],
+      shape: "standard",
+      shape_refloored: false,
+      plan_iter: 1,
+      eval_iter: 1
+    }
+  }' | jq "$trust_filter" >"$outfile"
+}
+
+# --------------------------------------------------------------------------
+# Test 11: valid trust telemetry → --trust-run-id / --trust-receipts /
+#          --trust-surfaceproof are forwarded to journal.sh
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/trust.json" "$stub" \
+    '.telemetry += {
+      trust_run_id: "run-390-abc",
+      trust_receipts: [{layer:"surfaceproof",mode:"shadow",verdict:"pass",stage:"analyze"},
+                       {layer:"evalseal",mode:"shadow",verdict:"inconclusive",stage:"evaluate"}],
+      trust_surfaceproof_shadow: {mode:"shadow",verdict:"pass",reason_code:null,receipt_id:"sha256:deadbeef"}
+    }'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-run-id run-390-abc"; then
+    pass "trust_run_id_forwarded"
+  else
+    fail "trust_run_id_forwarded" "expected --trust-run-id. got: ${captured}"
+  fi
+  if echo "$captured" | grep -q -- '--trust-receipts \[{"layer":"surfaceproof"'; then
+    pass "trust_receipts_forwarded"
+  else
+    fail "trust_receipts_forwarded" "expected --trust-receipts with compact JSON. got: ${captured}"
+  fi
+  if echo "$captured" | grep -q -- '--trust-surfaceproof {"mode":"shadow"'; then
+    pass "trust_surfaceproof_forwarded"
+  else
+    fail "trust_surfaceproof_forwarded" "expected --trust-surfaceproof with compact JSON. got: ${captured}"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/trust.json" ]]; then
+    pass "trust_pending_file_removed"
+  else
+    fail "trust_pending_file_removed" "pending file should be removed after success"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 12: trust keys absent (trust-inactive run) → no trust flags at all
+#          (既存呼び出しと byte 互換。AC-11: shadow/off で挙動不変)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/notrust.json" "$stub" '.'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-"; then
+    fail "trust_absent_no_flags" "no --trust-* flag expected. got: ${captured}"
+  else
+    pass "trust_absent_no_flags"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 13: trust_surfaceproof_shadow が closed-enum 契約違反 (verdict:null —
+#          advisory/blocking 昇格 run の形) → 当該フラグのみ drop し、base entry は記録される
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/badsp.json" "$stub" \
+    '.telemetry += {
+      trust_run_id: "run-390-xyz",
+      trust_surfaceproof_shadow: {mode:"advisory",verdict:null,reason_code:null,receipt_id:null}
+    }'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-surfaceproof"; then
+    fail "bad_surfaceproof_dropped" "invalid --trust-surfaceproof must not be forwarded. got: ${captured}"
+  else
+    pass "bad_surfaceproof_dropped"
+  fi
+  # base entry (と有効な trust_run_id) は失われない
+  if echo "$captured" | grep -q -- "--merge-tier REVIEW" &&
+    echo "$captured" | grep -q -- "--trust-run-id run-390-xyz"; then
+    pass "bad_surfaceproof_base_entry_preserved"
+  else
+    fail "bad_surfaceproof_base_entry_preserved" "base telemetry must still be logged. got: ${captured}"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/badsp.json" ]]; then
+    pass "bad_surfaceproof_pending_removed"
+  else
+    fail "bad_surfaceproof_pending_removed" "pending file must not be stuck on trust-key drop"
+  fi
+  if grep -q "trust-key-dropped: trust_surfaceproof_shadow" \
+    "${tmpd}/.claude/logs/stop-devflow-telemetry.log" 2>/dev/null; then
+    pass "bad_surfaceproof_logged"
+  else
+    fail "bad_surfaceproof_logged" "drop must be recorded in the log (silent drop 禁止)"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 14: trust_receipts に未知 layer → 当該フラグのみ drop、base entry は記録される
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/badrcpt.json" "$stub" \
+    '.telemetry += {
+      trust_receipts: [{layer:"unknownlayer",mode:"shadow",verdict:"pass"}]
+    }'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-receipts"; then
+    fail "bad_receipts_dropped" "invalid --trust-receipts must not be forwarded. got: ${captured}"
+  else
+    pass "bad_receipts_dropped"
+  fi
+  if echo "$captured" | grep -q -- "--merge-tier REVIEW"; then
+    pass "bad_receipts_base_entry_preserved"
+  else
+    fail "bad_receipts_base_entry_preserved" "base telemetry must still be logged. got: ${captured}"
+  fi
+  if grep -q "trust-key-dropped: trust_receipts" \
+    "${tmpd}/.claude/logs/stop-devflow-telemetry.log" 2>/dev/null; then
+    pass "bad_receipts_logged"
+  else
+    fail "bad_receipts_logged" "drop must be recorded in the log (silent drop 禁止)"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 15 (integration): 実 journal.sh が存在する環境では、trust キーが実際に
+#          journal entry の telemetry へ到達することを確認する（skills repo 側の
+#          --trust-* 受理契約との結合テスト）。未配置環境では skip。
+# --------------------------------------------------------------------------
+{
+  REAL_JOURNAL="${HOME}/ghq/github.com/it-all-playpark/skills/skill-retrospective/scripts/journal.sh"
+  if [[ ! -x $REAL_JOURNAL ]]; then
+    echo "  (skip: real journal.sh not found — integration test skipped)"
+  else
+    tmpd=$(make_tmpdir)
+    mkdir -p "${tmpd}/journal/pending"
+
+    make_trust_handoff "${tmpd}/journal/pending/e2e.json" "$REAL_JOURNAL" \
+      '.telemetry += {
+        trust_run_id: "run-e2e-001",
+        trust_receipts: [{layer:"evalseal",mode:"shadow",verdict:"pass",stage:"evaluate"}],
+        trust_surfaceproof_shadow: {mode:"shadow",verdict:"inconclusive"}
+      }'
+
+    run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+    entry=$(ls "${tmpd}/journal"/*.json 2>/dev/null | head -1 || true)
+    if [[ -z $entry ]]; then
+      fail "integration_entry_written" "no journal entry created. hook output: ${RUN_OUT}"
+    else
+      pass "integration_entry_written"
+      if [[ $(jq -r '.telemetry.trust_run_id' "$entry") == "run-e2e-001" ]] &&
+        [[ $(jq -r '.telemetry.trust_receipts[0].layer' "$entry") == "evalseal" ]] &&
+        [[ $(jq -r '.telemetry.trust_surfaceproof_shadow.verdict' "$entry") == "inconclusive" ]]; then
+        pass "integration_trust_keys_persisted"
+      else
+        fail "integration_trust_keys_persisted" "trust keys missing in entry: $(jq -c '.telemetry' "$entry")"
+      fi
+    fi
+
+    rm -rf "$tmpd"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 背景

`it-all-playpark/skills#390`（trust receipts epic）の Phase 5 Go/No-Go 判定が **No-Go** で止まっている。
理由は trust layer の不具合ではなく、**telemetry 配線がこの hook で切れていた**こと。

配線チェーンの実測結果:

| 区間 | 状態 |
|---|---|
| producer: `dev-flow.js` → handoff JSON (`trust_run_id` / `trust_receipts` / `trust_surfaceproof_shadow`) | ✅ 実装済 |
| consumer: `journal.sh` の `--trust-run-id` / `--trust-receipts` / `--trust-surfaceproof` 受理 | ✅ 実装済 (skills#413) |
| **本 hook: handoff JSON → journal.sh への転送** | ❌ **未配線（本 PR で解消）** |
| report: `trust-receipts-report.sh --slo` | ✅ 実装済 |

そのため 30d window の dev-flow run 45 件すべてで `trust_active_runs=0` となり、
`INSUFFICIENT_RUNS` / `LATENCY_UNMEASURABLE` で SLO 評価自体が成立していなかった。

## 変更

1. jq whitelist に `trust_run_id` / `trust_receipts` / `trust_surfaceproof_shadow` を追加
2. 抽出（`jq -c` で compact JSON、欠落時は空文字）
3. **journal.sh の closed-enum 契約を満たす値のみ転送する**

### 3 について（doc 記載の素朴な diff から意図的に変えた点）

`journal.sh` は `--trust-receipts` / `--trust-surfaceproof` を closed enum で検証し、違反時に
`die_json` exit 1 する。無検査で転送すると **entry 全体が pending へ差し戻され、`merge_tier` 等の
基本 telemetry ごと恒久的に失われる**（hook は失敗時にファイル名を戻して次回再試行するため、
契約違反 entry は永久にリトライされ続ける）。

実際に踏む経路がある: `dev-flow.js` は SurfaceProof mode が `shadow` 以外（= 将来の advisory /
blocking 昇格時）に `{mode:'advisory', verdict:null}` を emit する。これは journal.sh の enum を
満たさない。

そこで hook 側で同じ述語を先に評価し、**満たさない場合は当該フラグのみ drop してログに記録**する
（silent drop はしない）。optional な付加情報より base entry の記録を優先する fail-open。

## テスト

`bash claude-code/hooks/stop-devflow-telemetry.test.sh` → **48 passed, 0 failed**

追加した test 11–15:

- 11: 有効な trust キー 3 種が journal.sh へ転送される
- 12: trust 非活性 run では `--trust-*` が 1 つも付かない（既存呼び出しと byte 互換 / AC-11）
- 13: `verdict:null`（advisory 昇格 run の形）→ 当該フラグのみ drop、base entry は記録され
  pending にも残らない、ログに `trust-key-dropped` が出る
- 14: 未知 layer の receipts → 同上
- 15: **実 journal.sh との結合テスト** — trust キーが実際に journal entry の
  `telemetry.trust_run_id` / `trust_receipts[]` / `trust_surfaceproof_shadow` に到達することを確認
  （journal.sh 未配置環境では skip）

## 反映について

`~/.claude/hooks/stop-devflow-telemetry.sh` は本ファイルへの symlink のため、
main への merge 後は `nix run .#update` なしで即反映される。

## merge 後に必要なこと（本 PR のスコープ外）

1. 通常の dev-flow 運用で 20〜30 eligible runs を蓄積
2. `bash dev-flow-doctor/scripts/trust-receipts-report.sh --slo --window 30d` を再実行して Go/No-Go 再判定
3. `go` なら `_lib/trust-wiring.mjs` の `TRUST_LAYER_CONFIG` を shadow → advisory へ昇格する別 PR
   （その際 journal.sh の verdict enum に null 相当を足すか、producer 側で mode-only 形を
   別キーにするかの判断が必要 — 本 PR の drop 挙動が該当）

`TRUST_LAYER_CONFIG` / security floor / gate_policy / 人間 merge は一切変更していない（AC-15 非緩和）。

Refs: it-all-playpark/skills#390
