### PR TITLE
refactor(home-manager): hermes gateway を標準の `hermes gateway install` に移行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ gateway の launchd agent は dotfiles では定義せず、hermes 標準の
 出し分けるため、marker のある primary 機でだけ gateway が起動する。運用コマンドは
 `hermes gateway {status,start,stop,restart}`。
 
+marker のチェックは `nix run .#update` の activation 実行時のみで、launchd job 自体は
+一度 install されると KeepAlive で起動し続け、marker を消しても uninstall を実行するまで
+止まらない (fail-open)。そのため primary を切り替える際は **必ず旧機を先に止め終えてから**
+新機で marker を立てること。順序を誤ると新旧 2 台が同時に gateway を起動し、同じ App Token
+で multi-connect して二重応答になる (このリポジトリが防ごうとしている状態そのもの)。
+
+**primary 切替手順:**
+
+1. 旧機で `hermes gateway uninstall` を実行するか、`~/.hermes/.gateway-primary` を削除
+   してから `nix run .#update` を実行し、gateway が停止したことを確認する
+   （`hermes gateway status` で non-running を確認）。
+2. 旧機の停止を確認できてから、新機で `touch ~/.hermes/.gateway-primary` を実行し、
+   `nix run .#update` を実行する。
+
 ## セットアップ手順
 
 1. **ローカル設定ファイルの準備**

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ hermes-agent (全社横断 ChatOps 基盤) は個人PC設定とは性質が異�
 本リポジトリの `home-manager/home/default.nix` の `activation.setupHermes` が、
 その `hermes` リポジトリの checkout から `~/.hermes/` へ symlink を張る。
 
+gateway の launchd agent は dotfiles では定義せず、hermes 標準の
+`hermes gateway install` (label `ai.hermes.gateway`) に委ねる。`activation.setupHermes`
+が opt-in marker `~/.hermes/.gateway-primary` の有無を見て install / uninstall を
+出し分けるため、marker のある primary 機でだけ gateway が起動する。運用コマンドは
+`hermes gateway {status,start,stop,restart}`。
+
 ## セットアップ手順
 
 1. **ローカル設定ファイルの準備**

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -459,12 +459,11 @@ in
       fi
       ln -sf "$HERMES_REPO/repo_bindings.yaml" "$HERMES_DIR/repo_bindings.yaml"
 
-      # hermes-wrapper.sh — symlink。~/.hermes/.env を load してから real hermes を exec する。
-      # launchd agent と手動起動の双方で同じ env 注入経路を提供する。
-      if [ -f "$HERMES_DIR/hermes-wrapper.sh" ] && [ ! -L "$HERMES_DIR/hermes-wrapper.sh" ]; then
-        rm "$HERMES_DIR/hermes-wrapper.sh"
-      fi
-      ln -sf "$HERMES_REPO/hermes-wrapper.sh" "$HERMES_DIR/hermes-wrapper.sh"
+      # hermes-wrapper.sh — 廃止。hermes 本体 (hermes_cli/env_loader.py) が
+      # ~/.hermes/.env を override=True で load するため、wrapper による
+      # `set -a; . .env` は二重かつ dotenv とパース結果が食い違う (値の空白・#・
+      # クォートの扱い)。過去に張った symlink が残っていれば消す。
+      rm -f "$HERMES_DIR/hermes-wrapper.sh"
 
       # watchdog.sh (S5) — symlink。~/.hermes/jobs/*.json を定期 reconcile する
       # launchd agent (com.playpark.hermes-watchdog) から起動される。
@@ -495,6 +494,45 @@ in
         chmod 600 "$HERMES_DIR/.env"
         echo "hermes: created ~/.hermes/.env from template — fill in tokens before running"
       fi
+
+      # gateway service — hermes 標準の `hermes gateway install` に一本化する。
+      # 標準側 (hermes_cli/gateway.py) が ai.hermes.gateway.plist を生成し、
+      # PATH 合成・KeepAlive・ThrottleInterval・plist の陳腐化検知と自動更新
+      # (launchd_plist_is_current / refresh_launchd_plist_if_needed) を持つため、
+      # こちらで plist を書く必要がない。install は --force なしでも冪等で、
+      # 既存 plist が古ければ自動で書き直す。
+      #
+      # 二重起動防止の opt-in marker (~/.hermes/.gateway-primary) は標準側に
+      # 無い概念なので、marker の有無で install / uninstall を出し分けて
+      # 従来と同じ「primary 機でだけ起動する」意味を保つ。
+      LEGACY_LABEL="com.playpark.hermes-gateway"
+      LEGACY_PLIST="${config.home.homeDirectory}/Library/LaunchAgents/$LEGACY_LABEL.plist"
+
+      # 旧 plist の残骸を確実に停止・削除する。launchd.agents から定義を消せば
+      # home-manager が plist を消すが、load 済み job が残ると新旧 2 つの gateway が
+      # 同じ App Token で multi-connect し二重応答になるため、明示的に bootout する。
+      if [ -f "$LEGACY_PLIST" ] || launchctl print "gui/$(id -u)/$LEGACY_LABEL" >/dev/null 2>&1; then
+        launchctl bootout "gui/$(id -u)/$LEGACY_LABEL" 2>/dev/null || true
+        rm -f "$LEGACY_PLIST"
+        echo "hermes: removed legacy launchd agent $LEGACY_LABEL"
+      fi
+
+      HERMES_BIN="${config.home.homeDirectory}/.local/bin/hermes"
+      if [ ! -x "$HERMES_BIN" ]; then
+        echo "hermes: $HERMES_BIN not found — skipping gateway service setup"
+      elif [ -f "$HERMES_DIR/.gateway-primary" ]; then
+        # 標準 plist は install 時点の PATH を焼き込むため、docker/node が
+        # 解決できる PATH を明示してから install する (activation の PATH は
+        # nix profile 中心で /opt/homebrew 等を含まないことがある)。
+        PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+          "$HERMES_BIN" gateway install --start-on-login --no-start-now
+        # 未起動なら起動する。稼働中のセッションを毎回落とさないよう restart はしない
+        # (config.yaml 変更の反映は `hermes gateway restart` を明示的に実行する)。
+        "$HERMES_BIN" gateway start >/dev/null 2>&1 || true
+      else
+        echo "hermes: ~/.hermes/.gateway-primary not found on this host — gateway service not installed (opt-in via 'touch ~/.hermes/.gateway-primary')"
+        "$HERMES_BIN" gateway uninstall >/dev/null 2>&1 || true
+      fi
     '';
   };
 
@@ -513,49 +551,11 @@ in
     enable = true;
   };
 
-  # hermes gateway をログイン時に自動起動 (macOS 限定)
-  # Docker Desktop が未起動でも KeepAlive + ThrottleInterval で復旧するまで再試行。
-  #
-  # 同一 user account を複数 Mac で運用する場合の二重起動防止:
-  # opt-in marker `~/.hermes/.gateway-primary` が存在する host でだけ実際に起動する。
-  # marker 不在なら exit 0 で終了 (KeepAlive.SuccessfulExit=false なので restart しない)。
-  # 切り替え時は旧機で `rm`、新機で `touch` + `launchctl kickstart -k gui/$(id -u)/com.playpark.hermes-gateway`。
+  # hermes gateway の launchd agent はここでは定義しない。
+  # hermes 標準の `hermes gateway install` が生成する ai.hermes.gateway に一本化し、
+  # 呼び出しは activation.setupHermes が担う (marker の有無で install/uninstall)。
+  # 標準 plist は PATH 合成・KeepAlive・ThrottleInterval・陳腐化検知を自前で持つ。
   launchd.agents = lib.optionalAttrs pkgs.stdenv.isDarwin {
-    hermes-gateway = {
-      enable = true;
-      config = {
-        Label = "com.playpark.hermes-gateway";
-        ProgramArguments = [
-          "/bin/sh"
-          "-c"
-          ''
-            MARKER="${config.home.homeDirectory}/.hermes/.gateway-primary"
-            if [ ! -f "$MARKER" ]; then
-              echo "hermes-gateway: $MARKER not found on this host — skipping (opt-in via 'touch $MARKER')" >&2
-              exit 0
-            fi
-            /bin/wait4path "${config.home.homeDirectory}/.local/bin/hermes" \
-              && /bin/wait4path "${config.home.homeDirectory}/.hermes/hermes-wrapper.sh" \
-              && exec "${config.home.homeDirectory}/.hermes/hermes-wrapper.sh" gateway
-          ''
-        ];
-        EnvironmentVariables = {
-          PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${config.home.homeDirectory}/.local/bin";
-          HOME = config.home.homeDirectory;
-        };
-        WorkingDirectory = "${config.home.homeDirectory}/.hermes";
-        RunAtLoad = true;
-        KeepAlive = {
-          Crashed = true;
-          SuccessfulExit = false;
-        };
-        ProcessType = "Background";
-        StandardOutPath = "${config.home.homeDirectory}/.hermes/logs/gateway.out.log";
-        StandardErrorPath = "${config.home.homeDirectory}/.hermes/logs/gateway.err.log";
-        ThrottleInterval = 30;
-      };
-    };
-
     # hermes watchdog (S5, AC-4/AC-5) — ~/.hermes/jobs/*.json を定期 reconcile し、
     # 完了ジョブを Slack 通知 (notified dedup 付き) した上で workspace clone +
     # manifest を cleanup する。StartInterval で周期起動 (launchd は毎回新プロセス

--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -502,6 +502,20 @@ in
       # こちらで plist を書く必要がない。install は --force なしでも冪等で、
       # 既存 plist が古ければ自動で書き直す。
       #
+      # macOS 側の分岐 (`elif is_macos(): launchd_install(force)`) は force しか
+      # 見ない。`--start-on-login` / `--no-start-now` は systemd (Linux) /
+      # gateway_windows 専用の実装で、macOS では無視される — このリポジトリは
+      # macOS 専用なので付けても意味がなく、渡さない。
+      # install (force なし) の実際の挙動:
+      #   - plist 未設置 (初回 install): 新規生成して bootstrap。生成される plist は
+      #     RunAtLoad=true なので、フラグの有無に関わらずここで即起動する。
+      #   - plist が現行生成物と一致: 「既にインストール済み」で早期 return し、
+      #     bootout/bootstrap は起きない (稼働中セッションは落ちない)。
+      #   - plist が陳腐化: refresh_launchd_plist_if_needed() が書き直した上で
+      #     bootout → bootstrap するため、稼働中の gateway はここで再起動される。
+      # つまり「稼働中セッションを毎回落とさない」のは launchd_install 自身の
+      # 早期 return によるもので、フラグでは制御できない。
+      #
       # 二重起動防止の opt-in marker (~/.hermes/.gateway-primary) は標準側に
       # 無い概念なので、marker の有無で install / uninstall を出し分けて
       # 従来と同じ「primary 機でだけ起動する」意味を保つ。
@@ -524,10 +538,16 @@ in
         # 標準 plist は install 時点の PATH を焼き込むため、docker/node が
         # 解決できる PATH を明示してから install する (activation の PATH は
         # nix profile 中心で /opt/homebrew 等を含まないことがある)。
+        # macOS では install に渡せる意味のあるフラグは --force のみなので
+        # 付けない (上のコメント参照)。
         PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
-          "$HERMES_BIN" gateway install --start-on-login --no-start-now
-        # 未起動なら起動する。稼働中のセッションを毎回落とさないよう restart はしない
-        # (config.yaml 変更の反映は `hermes gateway restart` を明示的に実行する)。
+          "$HERMES_BIN" gateway install
+        # plist 未設置/陳腐化なら install が bootstrap まで済ませているので、
+        # ここは主に「plist は既にあるが launchd job が unload されている」場合の
+        # 保険 (gateway start は自己修復して bootstrap し直す)。稼働中セッションを
+        # 毎回落とさないのは install の早期 return によるもので、start 自体は
+        # 既に動いていれば何もしない (config.yaml 変更の反映は
+        # `hermes gateway restart` を明示的に実行する)。
         "$HERMES_BIN" gateway start >/dev/null 2>&1 || true
       else
         echo "hermes: ~/.hermes/.gateway-primary not found on this host — gateway service not installed (opt-in via 'touch ~/.hermes/.gateway-primary')"


### PR DESCRIPTION
## 背景

hermes 標準の `hermes gateway install/start/stop/restart/status` が launchd/systemd の
サービス管理を持っているのに、dotfiles 側で `com.playpark.hermes-gateway` plist を
手書きして並走させていた。標準側は plist の陳腐化検知と自動書き換え
(`launchd_plist_is_current` / `refresh_launchd_plist_if_needed`)、PATH 合成、
KeepAlive/ThrottleInterval を自前で持っており、自前 plist にはそれが無い。
また `hermes gateway status` が「Running manually, not as a system service」を返す
＝標準の status/doctor 系の可視性を失っていた。

## 変更

- `launchd.agents.hermes-gateway` を撤去し、`ai.hermes.gateway` に一本化
- `activation.setupHermes` が opt-in marker `~/.hermes/.gateway-primary` の有無で
  `hermes gateway install` / `uninstall` を出し分ける
- `hermes-wrapper.sh` の symlink を廃止
- 旧 plist を `launchctl bootout` + `rm` で明示撤去

## 設計判断

**opt-in marker を activation 側に移した理由**: 標準 plist に marker guard は無く、
無条件に install すると全 Mac で gateway が起動し、同じ Slack/Discord App Token で
multi-connect して二重応答になる。marker の意味を保つため install/uninstall の
出し分けに置き換えた。

**`--force` を使わない理由**: `install` は `--force` なしでも冪等で、既存 plist が
古ければ自動で書き直す (`hermes_cli/gateway.py:4240`)。毎 activation で安全に呼べる。

**`--no-start-now` + `gateway start` にした理由**: 稼働中の agent セッションを
`nix run .#update` のたびに落とさないため。config.yaml 変更の反映は従来どおり
明示的な `hermes gateway restart` で行う。

**wrapper を消せる根拠**: `hermes_cli/env_loader.py` が `~/.hermes/.env` を
`override=True` で load する (v0.19.0 で確認済み)。wrapper の `set -a; . .env` は
二重であり、POSIX sh の `.` は .env をシェルとして実行するので値に空白・`#`・
クォートが入ると python-dotenv と結果が食い違う。

## 検証

- `nix-instantiate --parse home-manager/home/default.nix` → OK
- 実機適用 (`nix run .#update`) は未実施。**マージ前に primary 機で要確認**:
  - `hermes gateway status` が service として認識されること
  - `~/Library/LaunchAgents/` から `com.playpark.hermes-gateway.plist` が消え
    `ai.hermes.gateway.plist` が生成されること
  - 生成 plist の `PATH` に docker が含まれること
  - Slack/Discord への応答が二重にならないこと

## 対象外

- watchdog (`com.playpark.hermes-watchdog`) は従来どおり。`hermes cron --no-agent`
  への移行は別 PR