### PR TITLE
fix(claude-code): telemetry hook の required-key 判定を producer 契約に合わせる

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -8,6 +8,15 @@
 # 各 *.json を atomic claim（mv + PID suffix）してから処理し、成功なら削除、
 # 失敗なら元のファイル名に戻す（次回 Stop で再試行）。
 #
+# malformed replay runbook（pending/malformed/ に落ちた handoff の回収手順）:
+#   1. mv ~/.claude/journal/pending/malformed/<file>.json ~/.claude/journal/pending/
+#   2. echo '{}' | bash ~/.claude/hooks/stop-devflow-telemetry.sh  # または次の Stop event
+#   3. ~/.claude/logs/stop-devflow-telemetry.log に journal-failed が無いことを確認
+#   注: outcome=failure かつ error_category/error_msg を欠く payload は journal.sh 契約
+#   （outcome != success で両キー必須）で journal-failed → pending/ に残り続ける。
+#   再投入前に payload へ error_category（enum: lint|test|build|runtime|config|env|merge|
+#   type-check|needs_clarification|empty_diff）と error_msg を手で追記すること。
+#
 # 無効化:
 #   - 環境変数 CLAUDE_DEVFLOW_TELEMETRY_HOOK=0（escape hatch）
 #   - pending dir が存在しない
@@ -71,6 +80,8 @@ for f in "${PENDING_DIR}"/*.json; do
   trust_run_id=""
   trust_receipts_json=""
   trust_surfaceproof_json=""
+  error_category=""
+  error_msg=""
 
   if ! parsed=$(jq -e '{
     skill: .skill,
@@ -79,6 +90,8 @@ for f in "${PENDING_DIR}"/*.json; do
     journal_sh: .journal_sh,
     repo: .repo,
     pr_number: .pr_number,
+    error_category: .error_category,
+    error_msg: .error_msg,
     merge_tier: .telemetry.merge_tier,
     gate_policy: .telemetry.gate_policy,
     danger_hits: (.telemetry.danger_hits // []),
@@ -107,8 +120,10 @@ for f in "${PENDING_DIR}"/*.json; do
   outcome=$(echo "$parsed" | jq -r '.outcome // empty')
   merge_tier=$(echo "$parsed" | jq -r '.merge_tier // empty')
 
-  # Required key check
-  if [[ -z $skill || -z $outcome || -z $merge_tier ]]; then
+  # Required key check（producer 契約 _lib/journal-handoff.mjs と一致: skill/outcome のみ必須。
+  # merge_tier は standard/complex shape 由来で micro shape や pr-iterate 単体起動には存在しない
+  # ため required から除外し、下流で conditional 転送する）
+  if [[ -z $skill || -z $outcome ]]; then
     mkdir -p "${PENDING_DIR}/malformed"
     mv "$claimed" "${PENDING_DIR}/malformed/$(basename "$f")"
     mkdir -p "$(dirname "$LOG_FILE")"
@@ -129,6 +144,8 @@ for f in "${PENDING_DIR}"/*.json; do
   eval_staleness=$(echo "$parsed" | jq -r '.eval_staleness // empty')
   repo=$(echo "$parsed" | jq -r '.repo // empty')
   pr_number=$(echo "$parsed" | jq -r '.pr_number // empty')
+  error_category=$(echo "$parsed" | jq -r '.error_category // empty')
+  error_msg=$(echo "$parsed" | jq -r '.error_msg // empty')
   ci_wait_seconds=$(echo "$parsed" | jq -r '.ci_wait_seconds // empty')
   ci_poll_attempts=$(echo "$parsed" | jq -r '.ci_poll_attempts // empty')
   trust_run_id=$(echo "$parsed" | jq -r '.trust_run_id // empty')
@@ -152,7 +169,16 @@ for f in "${PENDING_DIR}"/*.json; do
   cmd_args=(
     log "$skill" "$outcome"
     --issue "$issue"
-    --merge-tier "$merge_tier"
+  )
+
+  # merge_tier は standard/complex shape 由来の optional field（producer 契約は skill/outcome
+  # のみ必須）。micro shape run や pr-iterate 単体起動には存在しないため conditional 転送とし、
+  # 既存呼び出しとの引数順序 byte 互換のため --issue 直後に挿入する。
+  if [[ -n $merge_tier && $merge_tier != "null" ]]; then
+    cmd_args+=(--merge-tier "$merge_tier")
+  fi
+
+  cmd_args+=(
     --gate-policy "$gate_policy"
     --danger-hits "$danger_hits_json"
     --shape "$shape"
@@ -182,6 +208,14 @@ for f in "${PENDING_DIR}"/*.json; do
   fi
   if [[ -n $ci_poll_attempts && $ci_poll_attempts != "null" ]]; then
     cmd_args+=(--ci-poll-attempts "$ci_poll_attempts")
+  fi
+  # journal.sh は outcome != success のとき --error-category / --error-msg を必須とする
+  # （journal.sh L128-133）。これを欠くと失敗 run が journal-failed で pending に留まり続ける。
+  if [[ -n $error_category && $error_category != "null" ]]; then
+    cmd_args+=(--error-category "$error_category")
+  fi
+  if [[ -n $error_msg && $error_msg != "null" ]]; then
+    cmd_args+=(--error-msg "$error_msg")
   fi
 
   # --- trust telemetry (epic #390 Phase 5 / issue #413) ---

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -493,28 +493,367 @@ STUB_EOF
 }
 
 # --------------------------------------------------------------------------
-# Test 9: missing required key (no telemetry.merge_tier) → malformed treatment
+# Test 9: merge_tier absent (no telemetry.merge_tier) → NOT malformed, recorded
+#          without --merge-tier (producer 契約: required key は skill/outcome のみ)
 # --------------------------------------------------------------------------
 {
   tmpd=$(make_tmpdir)
   mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
 
-  # Valid JSON but missing required key
-  echo '{"skill":"dev-flow","outcome":"success","issue":1,"journal_sh":"/bin/true","telemetry":{}}' \
+  jq -n --arg js "$stub" \
+    '{"skill":"dev-flow","outcome":"success","issue":1,"journal_sh":$js,"telemetry":{}}' \
     >"${tmpd}/journal/pending/nokey.json"
 
   run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
 
   if [[ $RUN_EXIT -eq 0 ]]; then
-    pass "missing_key_exits_0"
+    pass "missing_merge_tier_exits_0"
   else
-    fail "missing_key_exits_0" "hook must always exit 0, got ${RUN_EXIT}"
+    fail "missing_merge_tier_exits_0" "hook must always exit 0, got ${RUN_EXIT}"
   fi
 
   if ls "${tmpd}/journal/pending/malformed/" 2>/dev/null | grep -q "nokey.json"; then
-    pass "missing_key_moved_to_malformed"
+    fail "missing_merge_tier_not_malformed" "merge_tier 欠落は malformed 扱いにしてはいけない（producer 契約は skill/outcome のみ必須）"
   else
-    fail "missing_key_moved_to_malformed" "file with missing required key should be in malformed/"
+    pass "missing_merge_tier_not_malformed"
+  fi
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if echo "$captured" | grep -q "log dev-flow success"; then
+      pass "missing_merge_tier_stub_called"
+    else
+      fail "missing_merge_tier_stub_called" "stub not called with expected skill/outcome. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--merge-tier"; then
+      fail "missing_merge_tier_no_flag" "--merge-tier must not appear when telemetry.merge_tier is absent. got: ${captured}"
+    else
+      pass "missing_merge_tier_no_flag"
+    fi
+  else
+    fail "missing_merge_tier_stub_called" "capture file not created (stub not called)"
+  fi
+
+  if [[ ! -f "${tmpd}/journal/pending/nokey.json" ]]; then
+    pass "missing_merge_tier_pending_removed"
+  else
+    fail "missing_merge_tier_pending_removed" "pending file should be removed after successful processing"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9b: skill missing → still malformed treatment (producer 契約違反)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+
+  echo '{"outcome":"success","issue":1,"journal_sh":"/bin/true","telemetry":{"merge_tier":"REVIEW"}}' \
+    >"${tmpd}/journal/pending/noskill.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ $RUN_EXIT -eq 0 ]]; then
+    pass "missing_skill_exits_0"
+  else
+    fail "missing_skill_exits_0" "hook must always exit 0, got ${RUN_EXIT}"
+  fi
+
+  if ls "${tmpd}/journal/pending/malformed/" 2>/dev/null | grep -q "noskill.json"; then
+    pass "missing_skill_moved_to_malformed"
+  else
+    fail "missing_skill_moved_to_malformed" "handoff missing skill must be moved to malformed/"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9c: outcome missing → still malformed treatment (producer 契約違反)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+
+  echo '{"skill":"dev-flow","issue":1,"journal_sh":"/bin/true","telemetry":{"merge_tier":"REVIEW"}}' \
+    >"${tmpd}/journal/pending/nooutcome.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ $RUN_EXIT -eq 0 ]]; then
+    pass "missing_outcome_exits_0"
+  else
+    fail "missing_outcome_exits_0" "hook must always exit 0, got ${RUN_EXIT}"
+  fi
+
+  if ls "${tmpd}/journal/pending/malformed/" 2>/dev/null | grep -q "nooutcome.json"; then
+    pass "missing_outcome_moved_to_malformed"
+  else
+    fail "missing_outcome_moved_to_malformed" "handoff missing outcome must be moved to malformed/"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9d: dev-flow 失敗 run（malformed 実データ系統A を模す）→ error_category /
+#          error_msg (top-level) が --error-category / --error-msg として転送される
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  jq -n --arg js "$stub" \
+    '{
+      skill: "dev-flow",
+      outcome: "failure",
+      issue: 325,
+      repo: "it-all-playpark/skills",
+      journal_sh: $js,
+      error_category: "needs_clarification",
+      error_msg: "analyze: 要件が曖昧で中断",
+      telemetry: {
+        gate_policy: "llm-major-advisory",
+        plan_iter: 0,
+        eval_iter: 0
+      }
+    }' >"${tmpd}/journal/pending/failrun.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if echo "$captured" | grep -q "log dev-flow failure"; then
+      pass "failrun_skill_outcome"
+    else
+      fail "failrun_skill_outcome" "expected 'log dev-flow failure'. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--error-category needs_clarification"; then
+      pass "failrun_error_category"
+    else
+      fail "failrun_error_category" "--error-category needs_clarification not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--error-msg"; then
+      pass "failrun_error_msg"
+    else
+      fail "failrun_error_msg" "--error-msg not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--gate-policy llm-major-advisory"; then
+      pass "failrun_gate_policy"
+    else
+      fail "failrun_gate_policy" "--gate-policy llm-major-advisory not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--merge-tier"; then
+      fail "failrun_no_merge_tier" "--merge-tier must not appear. got: ${captured}"
+    else
+      pass "failrun_no_merge_tier"
+    fi
+  else
+    fail "failrun_stub_called" "capture file not created (stub not called)"
+  fi
+
+  if [[ ! -f "${tmpd}/journal/pending/failrun.json" ]]; then
+    pass "failrun_pending_removed"
+  else
+    fail "failrun_pending_removed" "pending file should be removed after successful processing"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9e: pr-iterate 単体起動 handoff（系統B）→ iterate_status / ci_wait_seconds /
+#          ci_poll_attempts / pr_number が転送され、merge-tier/error-category は無い
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  jq -n --arg js "$stub" \
+    '{
+      skill: "pr-iterate",
+      outcome: "success",
+      repo: "it-all-playpark/skills",
+      pr_number: 99,
+      journal_sh: $js,
+      telemetry: {
+        iterate_status: "converged",
+        ci_wait_seconds: 120,
+        ci_poll_attempts: 3
+      }
+    }' >"${tmpd}/journal/pending/priterate.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if echo "$captured" | grep -q "log pr-iterate success"; then
+      pass "priterate_skill_outcome"
+    else
+      fail "priterate_skill_outcome" "expected 'log pr-iterate success'. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--iterate-status converged"; then
+      pass "priterate_iterate_status"
+    else
+      fail "priterate_iterate_status" "--iterate-status converged not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--ci-wait-seconds 120"; then
+      pass "priterate_ci_wait_seconds"
+    else
+      fail "priterate_ci_wait_seconds" "--ci-wait-seconds 120 not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--ci-poll-attempts 3"; then
+      pass "priterate_ci_poll_attempts"
+    else
+      fail "priterate_ci_poll_attempts" "--ci-poll-attempts 3 not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--pr-number 99"; then
+      pass "priterate_pr_number"
+    else
+      fail "priterate_pr_number" "--pr-number 99 not found. got: ${captured}"
+    fi
+    if echo "$captured" | grep -q -- "--merge-tier"; then
+      fail "priterate_no_merge_tier" "--merge-tier must not appear. got: ${captured}"
+    else
+      pass "priterate_no_merge_tier"
+    fi
+    if echo "$captured" | grep -q -- "--error-category"; then
+      fail "priterate_no_error_category" "--error-category must not appear. got: ${captured}"
+    else
+      pass "priterate_no_error_category"
+    fi
+  else
+    fail "priterate_stub_called" "capture file not created (stub not called)"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9f: 最小 payload {skill, outcome, journal_sh}（telemetry object 自体なし）
+#          → 記録成功・pending 削除
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  jq -n --arg js "$stub" '{skill: "pr-iterate", outcome: "success", journal_sh: $js}' \
+    >"${tmpd}/journal/pending/minimal.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ $RUN_EXIT -eq 0 ]]; then
+    pass "minimal_payload_exits_0"
+  else
+    fail "minimal_payload_exits_0" "expected exit 0, got ${RUN_EXIT}. output: ${RUN_OUT}"
+  fi
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if echo "$captured" | grep -q "log pr-iterate success"; then
+      pass "minimal_payload_stub_called"
+    else
+      fail "minimal_payload_stub_called" "expected 'log pr-iterate success'. got: ${captured}"
+    fi
+  else
+    fail "minimal_payload_stub_called" "capture file not created (stub not called)"
+  fi
+
+  if [[ ! -f "${tmpd}/journal/pending/minimal.json" ]]; then
+    pass "minimal_payload_pending_removed"
+  else
+    fail "minimal_payload_pending_removed" "pending file should be removed after successful processing"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9g: telemetry.merge_tier が JSON null → --merge-tier は付与されない
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  jq -n --arg js "$stub" \
+    '{skill:"dev-flow", outcome:"success", issue:5, journal_sh:$js, telemetry:{merge_tier:null}}' \
+    >"${tmpd}/journal/pending/nulltier.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if echo "$captured" | grep -q -- "--merge-tier"; then
+      fail "null_merge_tier_no_flag" "--merge-tier must not appear when telemetry.merge_tier is null. got: ${captured}"
+    else
+      pass "null_merge_tier_no_flag"
+    fi
+  else
+    fail "null_merge_tier_stub_called" "capture file not created (stub not called)"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test 9h (regression / byte compat): merge_tier を持つ既存 handoff の cmd_args が
+#          exact-match で現状と一致する（--merge-tier の挿入位置が --issue 直後から
+#          動いていないことの証明）
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  jq -n --arg js "$stub" \
+    '{
+      skill: "dev-flow",
+      outcome: "success",
+      issue: 203,
+      journal_sh: $js,
+      telemetry: {
+        merge_tier: "REVIEW",
+        gate_policy: "llm-major-advisory",
+        danger_hits: [],
+        shape: "standard",
+        shape_refloored: false,
+        plan_iter: 1,
+        eval_iter: 1
+      }
+    }' >"${tmpd}/journal/pending/regression.json"
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  expected='log dev-flow success --issue 203 --merge-tier REVIEW --gate-policy llm-major-advisory --danger-hits [] --shape standard --shape-refloored false --plan-iter 1 --eval-iter 1'
+
+  if [[ -f $capture ]]; then
+    captured=$(cat "$capture")
+    if [[ $captured == "$expected" ]]; then
+      pass "regression_exact_arg_order"
+    else
+      fail "regression_exact_arg_order" "expected: [${expected}] got: [${captured}]"
+    fi
+  else
+    fail "regression_exact_arg_order" "capture file not created (stub not called)"
   fi
 
   rm -rf "$tmpd"


### PR DESCRIPTION
## 背景

Stop hook (`claude-code/hooks/stop-devflow-telemetry.sh`) の required-key 判定が `merge_tier` を必須としているが、producer 側 (`_lib/journal-handoff.mjs`) は `skill` / `outcome` の 2 つしか必須にしていない。

`merge_tier` は standard/complex shape 由来のため、**dev-flow の失敗 run と pr-iterate 単体起動には存在しない**。結果、これらの handoff がすべて `missing-required-key` で `pending/malformed/` へ落ち、telemetry が全損していた（`~/.claude/logs/stop-devflow-telemetry.log` に 10 件）。

## 変更

- **required-key 判定を `skill` / `outcome` のみに変更** — producer 契約と一致させる
- **`--merge-tier` を conditional 転送化** — 既存呼び出しとの引数順序 byte 互換のため `--issue` 直後に挿入
- **`error_category` / `error_msg` を jq projection と転送対象に追加** — journal.sh は `outcome != success` のとき両キーを必須とする（journal.sh L128-133）ため、これを欠くと失敗 run が `journal-failed` で pending に留まり続ける
- **malformed replay runbook** をスクリプト先頭コメントに記載

## テスト

```
bash claude-code/hooks/stop-devflow-telemetry.test.sh
=== Results: 73 passed, 0 failed ===
```

追加ケース（+353行）:

| ケース | 検証内容 |
|---|---|
| `regression_exact_arg_order` | merge_tier ありの handoff が**現状と byte 互換**（回帰なし） |
| `priterate_no_merge_tier` | merge_tier 欠落 handoff が malformed へ落ちず記録される |
| `priterate_iterate_status` / `_ci_wait_seconds` / `_ci_poll_attempts` | pr-iterate 単体起動の telemetry 到達 |
| `failrun_*` | 失敗 run の error_category / error_msg 到達 |
| `null_merge_tier_no_flag` | null 値でフラグを立てない |
| `minimal_payload_*` | skill / outcome のみの最小 payload が通る |

## 受け入れ条件

- [x] `merge_tier` を欠く handoff が `malformed/` へ落ちず journal entry として記録される
- [x] `merge_tier` を持つ handoff の記録内容は現状と byte 互換（回帰なし）
- [x] required-key 判定が producer 契約（`skill` / `outcome`）と一致する
- [x] `error_category` / `error_msg` が失敗 run の journal entry に到達する
- [x] pr-iterate 単体起動で `iterate_status` / `ci_wait_seconds` / `ci_poll_attempts` が記録される
- [x] hook のテストに「merge_tier 欠落 handoff が正常記録される」ケースを追加
- [ ] **既存 `pending/malformed/` の 11 件の実データ replay は未実行**（runbook は記載済み）

## 残作業・注意

**実データ replay 未検証。** `~/.claude/journal/pending/malformed/` に 11 件が残っている。内訳を確認した限り 10 件は本 PR で回収可能（例: `devflow-14` は outcome=failure だが `error_category` / `error_msg` を保持、`priterate-99` は success かつ merge_tier 不要）。残る `devflow-411` (17KB) は `vdelta_verdicts` の raw JSON 埋め込みでエスケープが壊れている **別原因**で、it-all-playpark/skills#431 が別 issue へ明示的に繰り延べている。

**本 hook は `~/.claude/hooks/` から symlink されているため、この変更は作業ツリー上で既に稼働している。**

Refs: it-all-playpark/skills#431