### PR TITLE
fix(deskflow): 切替ホットキーを修飾キーなしの F13/F14 に変更する

### DIFF
--- a/home-manager/home/file/deskflow/README.md
+++ b/home-manager/home/file/deskflow/README.md
@@ -51,13 +51,45 @@ GUI のホットキー録音は Qt の macOS ctrl/meta swap により物理 ⌃ 
 
 | 物理キー | 動作 |
 | --- | --- |
-| ⌘⌃T | MacBook Pro (`OMBP-M3P.local`) へ切替 |
-| ⌘⌃S | Mac Studio (`USERnoMac-Studio.local`) へ切替 |
+| F13 | MacBook Pro (`OMBP-M3P.local`) へ切替 |
+| F14 | Mac Studio (`USERnoMac-Studio.local`) へ切替 |
 
-大西配列の t=左 / s=右 に合わせてある。⌘ を含む組み合わせは ghostty が消費して
-zellij・nvim・fish には届かないので、`Alt+t/n/r/s` や `Ctrl+Alt+t/n/r/s` を使う
-zellij とは衝突しない。macOS システムホットキー（⌘⌃ の英字は ⌃⌘D のみ）、
-ghostty デフォルト（⌘⌃ は `f` `=` 矢印 `⇧J`）、Raycast（⌘Space）とも未使用を確認済み。
+ZMK キーボード (`zmk-config-fish`) の `layer_navi` から出している。右親指の
+`&lt 2 ESC` を押しながら、左小指ホーム (position 9) が F13、右小指ホーム
+(position 18) が F14。
+
+**キー名は大文字小文字を区別する**。`kKeyNameMap` にあるのは `F13` であって
+`f13` ではない。`F13`〜`F35` が使える。
+
+## なぜ修飾キーを使わないのか
+
+以前は物理 ⌘⌃T / ⌘⌃S を使っていたが、macOS サーバーでは**修飾キーを含む
+ホットキーは必ず入力状態を壊す**。
+
+ホットキーが押されている最中に画面切替が発動するため、`⌃ up` / `⌘ up` が
+**切替先の機体に飛び、サーバーは release を一度も受け取らない**。結果として
+サーバー側で修飾キーが押しっぱなしになり、
+
+- 長押しが `ctrl+ctrl` / `⌘+⌘` の二重押しとして認識される
+- トラックパッドのクリックが ⌃クリック・⌘クリック扱いになる
+- Bluetooth の接続先を切り替えて戻すと直る（HID 再列挙で状態がリセットされるため）
+
+という症状が出る。修飾キーを含まない単発キーならこの経路が成立しない。ZMK の
+`&lt`（layer-tap）のホールドはレイヤー切替が firmware 内部で完結し**ホストに
+何も送らない**ので、レイヤーキー自体も Deskflow からは見えない。
+
+F13/F14 は英数字の範囲外なので、macOS システムホットキー・ghostty・zellij・
+Raycast のいずれとも原理的に衝突しない。
+
+## 既知の未解決バグ（upstream）
+
+`OSXScreen::leave()` がカーソルを画面中央に warp せず `m_xCursor`/`m_yCursor` を
+更新しないため、baseline が stale になる（deskflow/deskflow#9779、open）。
+`MSWindowsScreen::leave()` と `XWindowsScreen::leave()` は両方 warp するので
+**macOS サーバーだけの欠陥**。ホットキー切替で発火し、エッジ切替では起きない。
+
+サーバー側でカーソルが動かなくなる症状はこれが原因の可能性がある。修飾キーの
+stuck とは独立した問題なので、F13/F14 化しても残るなら upstream 修正が必要。
 
 ## 編集時の注意
 

--- a/home-manager/home/file/deskflow/deskflow-server.conf
+++ b/home-manager/home/file/deskflow/deskflow-server.conf
@@ -35,10 +35,26 @@ section: options
 	clipboardSharingSize = 3072
 	switchCorners = none
 	switchCornerSize = 0
-	# Hotkeys: physical Command+Control+T / +S (Mac Studio is the server).
+	# Hotkeys: F13 / F14 (Mac Studio is the server). The ZMK keyboard emits them
+	# from layer_navi - hold the right thumb "lt 2" key, then the left pinky home
+	# position for F13 (MacBook Pro) or the right pinky home for F14 (Mac Studio).
 	#
-	# IMPORTANT - on a macOS server the modifier NAMES below do not mean what
-	# they look like. OSXKeyState::mapDeskflowHotKeyToMac() converts them as:
+	# Deliberately NO modifiers. The screen switch fires while the hotkey is still
+	# physically held down, so the key-up events land on the machine we just
+	# switched to and this server never sees them. With the previous
+	# Command+Control+T/S that left Command and Control stuck down here: held keys
+	# were read as ctrl+ctrl / cmd+cmd, and trackpad clicks became ctrl-clicks
+	# until the keyboard was re-paired over Bluetooth. A single non-modifier key
+	# cannot get stuck that way. A ZMK layer-tap sends nothing to the host while
+	# held, so the layer key itself is invisible to Deskflow too.
+	#
+	# Key names are CASE SENSITIVE - kKeyNameMap holds "F13", not "f13".
+	# F13 through F35 are all accepted. F13/F14 are unused by macOS symbolic
+	# hotkeys, ghostty, zellij and Raycast, and being outside the alphanumeric
+	# range they cannot collide with the terminal stack at all.
+	#
+	# If modifiers are ever reintroduced here, remember that their NAMES are
+	# remapped by OSXKeyState::mapDeskflowHotKeyToMac():
 	#   Shift   -> Shift
 	#   Control -> Control
 	#   Alt     -> Command   (NOT Option)
@@ -47,14 +63,6 @@ section: options
 	# The Deskflow GUI hotkey recorder writes "Meta"/"Control" for the physical
 	# Control/Command keys, which is why GUI-recorded hotkeys are dead here.
 	# Keep editing this file by hand; do not turn off externalConfig.
-	#
-	# Two modifiers are enough because Command never reaches the terminal stack:
-	# zellij (Alt+t/n/r/s, Ctrl+Alt+t/n/r/s), nvim (<C-*>) and fish only ever see
-	# keys ghostty forwards, and ghostty consumes Command itself.
-	# Verified free for T/S: macOS symbolic hotkeys (only Ctrl+Cmd+D is bound),
-	# ghostty defaults (Ctrl+Cmd is used for f, =, arrows, Shift+J only),
-	# Raycast (Command+Space). Ctrl+Cmd+F/Q/D/Space are the widely used ones and
-	# T/S avoid all of them.
-	keystroke(Alt+Control+t) = switchToScreen(OMBP-M3P.local)
-	keystroke(Alt+Control+s) = switchToScreen(USERnoMac-Studio.local)
+	keystroke(F13) = switchToScreen(OMBP-M3P.local)
+	keystroke(F14) = switchToScreen(USERnoMac-Studio.local)
 end


### PR DESCRIPTION
## 背景

Mac Studio (deskflow server) 側で入力異常が頻発していた。

- Ctrl / ⌘ の長押しが `ctrl+ctrl` / `⌘+⌘` の二重押しとして認識される
- トラックパッドのクリックが ⌃クリック・⌘クリック扱いになる
- Bluetooth の接続先を切り替えて戻すと直る
- カーソルが動かなくなる (これは別原因、後述)

## 原因

切替ホットキーが物理 ⌘⌃T / ⌘⌃S だったこと。

ホットキーが押されている最中に画面切替が発動するため、フォーカスが相手機に移り
`⌃ up` / `⌘ up` が**切替先の機体に飛ぶ**。サーバーは release を一度も受け取らないので、
修飾キーが押しっぱなしのまま残る。

修飾キーをホットキーに使う限り構造的に避けられない。

## 変更内容

| | 変更前 | 変更後 |
|---|---|---|
| MacBook Pro へ切替 | `keystroke(Alt+Control+t)` | `keystroke(F13)` |
| Mac Studio へ切替 | `keystroke(Alt+Control+s)` | `keystroke(F14)` |

キーは ZMK 側から供給する (it-all-playpark/zmk-config-fish#1)。`layer_navi` で右親指の
`&lt 2 ESC` を押しながら、左小指ホーム (position 9) = F13 / 右小指ホーム (position 18) = F14。

ZMK の `&lt` (layer-tap) のホールドは**ホストに何も送らない**ためレイヤーキー自体も
Deskflow からは見えず、キーボードだけで完結する。

README には修飾キーを使わない理由と upstream の未解決バグを追記。

## 注意点

**キー名は case-sensitive。** `kKeyNameMap` にあるのは `F13` であって `f13` ではない。
`F13`〜`F35` が使える。英数字の範囲外なので macOS システムホットキー・ghostty・zellij・
Raycast のいずれとも原理的に衝突しない。

修飾キー名の反転 (`Alt` = ⌘, `Super` = ⌥, `Meta` = 黙って破棄) の記述は、将来また
修飾キーを使う場合に備えて conf / README に残してある。

## 検証

- `nix fmt` → 70 files, **0 changed** (フォーマット適合済み)
- conf の非 ASCII 文字 0 件 (`ConfigReadContext::readLine()` の `isgraph` 検査対策)
- `section: options` の構造と `end` が維持されていることを確認

## マージ前に必要な手動作業

`~/Library/Deskflow/Deskflow.conf` の `externalConfigFile` が
`~/Library/Deskflow/deskflow-server.conf` を指しており、**dotfiles 側の symlink
(`~/.config/deskflow/deskflow-server.conf`) を読んでいない**。このままでは本 PR の変更が
反映されない。Deskflow を終了させてから書き換える必要がある (GUI 起動中は上書きされる)。

ZMK 側のファーム書き込みも必要。

## 未解決 (別問題)

サーバー側でカーソルが動かなくなる症状は upstream deskflow/deskflow#9779 の可能性が高い。
`OSXScreen::leave()` がカーソルを画面中央に warp せず `m_xCursor`/`m_yCursor` を更新しないため
baseline が stale になる欠陥で、`MSWindowsScreen::leave()` と `XWindowsScreen::leave()` は
両方 warp するため **macOS サーバー限定**。ホットキー切替で発火しエッジ切替では起きない。open のまま未修正。

修飾キー stuck とは独立した問題なので、本 PR 適用後もカーソル固着が残るなら upstream 修正が必要。