### PR TITLE
🐛 fix: fix(pr-iterate): post-summary subagent が PR の自己承認を試みる（「merge は常に人間」invariant 違反） (#137)

### DIFF
--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -53,6 +53,7 @@ nix run .#update
 | `PreToolUse` Write (`*/SKILL.md`) | `validate-skill-frontmatter.sh` | skill frontmatter 検証 |
 | `PreToolUse` Bash (`git push*`) | `allow-feature-push.sh` | protected branch への push を抑止 |
 | `PreToolUse` Bash | `pretool-bash-credential-guard.sh` | prod credential を含むコマンドを抑止 |
+| `PreToolUse` Bash | `pretool-gh-pr-self-approve-guard.sh` | `gh pr review --approve` による PR self-approve を deny（merge/approve は常に人間） |
 | `PreToolUse` Bash (`git worktree add*`) | `generate-worktreeinclude.sh` | `.worktreeinclude` 自動生成 |
 | `PreToolUse` Bash (`gh pr merge*`) | `allow-pr-merge.sh` | merge 先 branch チェック |
 | `PostToolUse` 系 | `posttool-secret-mask.sh` | 出力中の secret をマスク |

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# PreToolUse(Bash) hook: gh pr review --approve（self-approve）の検知・deny
+#
+# 目的:
+#   merge/approve は常に人間が行う invariant を、プロンプト指示のみに依存せず
+#   決定論的な hook で担保する（issue #137）。
+#
+# 検知対象:
+#   コマンド文字列内に `gh ... pr review ...` 呼び出しが存在し、かつ
+#   standalone token として `--approve` または `-a` が含まれる場合。
+#   - 引数順序に依らない（`gh pr review --approve 137` / `gh pr review 137 --approve` 等）
+#   - `gh -R owner/repo pr review ...` のようなグローバルフラグ挟み込みも検出
+#   - `git fetch && gh pr review 137 --approve` のような compound command 内も検出
+#     （settings.json 側で matcher を "Bash(gh pr review*)" のような前方一致に
+#     せず、全 Bash コマンドで本 hook を起動する前提）
+#
+# fail-closed 仕様:
+#   `--body "please --approve later"` のように引用文字列内に --approve token が
+#   含まれる場合も deny する（安全側）。シェル引用の完全パースは非現実的なため、
+#   偽陽性を許容し fail-closed に倒す。
+#
+# 素通しする例:
+#   - `gh pr review 137 --comment --body "looks good"`
+#   - `gh pr review 137 --request-changes --body "fix"`
+#   - `gh pr view 137` / `gh pr merge 137`（pr review 呼び出しでない）
+#   - `git commit -a -m msg` / `ls -a`（pr review 呼び出しでない -a）
+#
+# 出力:
+#   - 検知時: stdout に
+#       {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#         "permissionDecision":"deny",
+#         "permissionDecisionReason":"<理由>"}}
+#   - 非検知時: stdout 空で exit 0（チェーン通過 → Claude 通常の permission flow）
+
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ -z $CMD ]]; then
+  exit 0
+fi
+
+# gh ... pr review ... の呼び出し検出（compound command 内・グローバルフラグ挟み込み含む）
+PR_REVIEW_RE='(^|[;&|[:space:]])gh([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+pr[[:space:]]+review([[:space:]]|$)'
+
+# standalone token としての --approve / -a 検出（--approver / -abc に誤爆しない）
+APPROVE_TOKEN_RE='(^|[[:space:]])(--approve|-a)([[:space:]]|$)'
+
+if echo "$CMD" | grep -qE "$PR_REVIEW_RE" && echo "$CMD" | grep -qE "$APPROVE_TOKEN_RE"; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR self-approve は禁止（merge/approve は常に人間が行う invariant）"}}'
+  exit 0
+fi
+
+exit 0

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
@@ -45,7 +45,9 @@ fi
 PR_REVIEW_RE='(^|[;&|[:space:]])gh([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+pr[[:space:]]+review([[:space:]]|$)'
 
 # standalone token としての --approve / -a 検出（--approver / -abc に誤爆しない）
-APPROVE_TOKEN_RE='(^|[[:space:]])(--approve|-a)([[:space:]]|$)'
+# --approve=true / -a=true のような cobra 形式（`=` 区切り値）も検出する
+# （--approve=false も fail-closed で deny する: 安全側）
+APPROVE_TOKEN_RE='(^|[[:space:]])(--approve(=[^[:space:]]*)?|-a(=[^[:space:]]*)?)([[:space:]]|$)'
 
 if echo "$CMD" | grep -qE "$PR_REVIEW_RE" && echo "$CMD" | grep -qE "$APPROVE_TOKEN_RE"; then
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR self-approve は禁止（merge/approve は常に人間が行う invariant）"}}'

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.sh
@@ -47,7 +47,11 @@ PR_REVIEW_RE='(^|[;&|[:space:]])gh([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:sp
 # standalone token としての --approve / -a 検出（--approver / -abc に誤爆しない）
 # --approve=true / -a=true のような cobra 形式（`=` 区切り値）も検出する
 # （--approve=false も fail-closed で deny する: 安全側）
-APPROVE_TOKEN_RE='(^|[[:space:]])(--approve(=[^[:space:]]*)?|-a(=[^[:space:]]*)?)([[:space:]]|$)'
+# 境界は PR_REVIEW_RE と対称に compound command 区切り（;&|）も含める。
+# 末尾は `--approve; echo` / `--approve&&x` / `--approve|cat` のような
+# 区切り文字直後の token も検出できるよう [;&|<>[:space:]] まで広げる
+# （fail-closed: 誤検知より見逃しを避ける）
+APPROVE_TOKEN_RE='(^|[;&|[:space:]])(--approve(=[^[:space:]]*)?|-a(=[^[:space:]]*)?)([;&|<>[:space:]]|$)'
 
 if echo "$CMD" | grep -qE "$PR_REVIEW_RE" && echo "$CMD" | grep -qE "$APPROVE_TOKEN_RE"; then
   echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PR self-approve は禁止（merge/approve は常に人間が行う invariant）"}}'

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
@@ -60,6 +60,10 @@ run_case "compound command with &&" 'git fetch && gh pr review 137 --approve' "d
 run_case "pr review --approve=true (cobra = form)" 'gh pr review 137 --approve=true' "deny"
 run_case "pr review -a=true (cobra = form)" 'gh pr review 137 -a=true' "deny"
 run_case "pr review --approve=false (fail-closed)" 'gh pr review 137 --approve=false' "deny"
+run_case "pr review --approve then ; compound (no space)" 'gh pr review 137 --approve; echo done' "deny"
+run_case "pr review -a then ; compound (no space)" 'gh pr review -a; echo done' "deny"
+run_case "pr review --approve then && compound" 'gh pr review 137 --approve&&echo done' "deny"
+run_case "pr review --approve then | pipe" 'gh pr review 137 --approve|cat' "deny"
 
 # --- Negative cases: should NOT trigger (pass through) ---
 echo "[Negative cases — should pass through]"

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
@@ -57,6 +57,9 @@ run_case "pr review -a only" 'gh pr review -a' "deny"
 run_case "pr review with -R global flag" 'gh -R it-all-playpark/dotfiles pr review 137 --approve' "deny"
 run_case "pr review --approve with --body" 'gh pr review 137 --approve --body "LGTM"' "deny"
 run_case "compound command with &&" 'git fetch && gh pr review 137 --approve' "deny"
+run_case "pr review --approve=true (cobra = form)" 'gh pr review 137 --approve=true' "deny"
+run_case "pr review -a=true (cobra = form)" 'gh pr review 137 -a=true' "deny"
+run_case "pr review --approve=false (fail-closed)" 'gh pr review 137 --approve=false' "deny"
 
 # --- Negative cases: should NOT trigger (pass through) ---
 echo "[Negative cases — should pass through]"

--- a/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
+++ b/claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Test suite for pretool-gh-pr-self-approve-guard.sh
+#
+# Usage: bash pretool-gh-pr-self-approve-guard.test.sh
+#
+# Exit 0 on all pass, non-zero otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/pretool-gh-pr-self-approve-guard.sh"
+
+if [[ ! -x ${HOOK} ]]; then
+  echo "FAIL: hook not executable: ${HOOK}" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# run_case <name> <command> <expected: deny|pass>
+run_case() {
+  local name="$1"
+  local cmd="$2"
+  local expected="$3"
+
+  local input
+  input=$(jq -n --arg cmd "$cmd" '{tool_name:"Bash", tool_input:{command:$cmd}}')
+
+  local output
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+
+  local decision="pass"
+  if [[ -n $output ]]; then
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null || echo "pass")
+  fi
+
+  if [[ $decision == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    printf "  \033[32mPASS\033[0m %s\n" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected=$expected got=$decision cmd=$cmd")
+    printf "  \033[31mFAIL\033[0m %s (expected=%s, got=%s)\n" "$name" "$expected" "$decision"
+  fi
+}
+
+echo "=== pretool-gh-pr-self-approve-guard tests ==="
+
+# --- Positive cases: should trigger "deny" ---
+echo "[Positive cases — should deny]"
+run_case "pr review --approve trailing" 'gh pr review 137 --approve' "deny"
+run_case "pr review --approve leading" 'gh pr review --approve 137' "deny"
+run_case "pr review -a trailing" 'gh pr review 137 -a' "deny"
+run_case "pr review -a only" 'gh pr review -a' "deny"
+run_case "pr review with -R global flag" 'gh -R it-all-playpark/dotfiles pr review 137 --approve' "deny"
+run_case "pr review --approve with --body" 'gh pr review 137 --approve --body "LGTM"' "deny"
+run_case "compound command with &&" 'git fetch && gh pr review 137 --approve' "deny"
+
+# --- Negative cases: should NOT trigger (pass through) ---
+echo "[Negative cases — should pass through]"
+run_case "pr review --comment with body" 'gh pr review 137 --comment --body "looks good"' "pass"
+run_case "pr review --request-changes with body" 'gh pr review 137 --request-changes --body "fix"' "pass"
+run_case "pr review --comment only" 'gh pr review 137 --comment' "pass"
+run_case "pr view (not review)" 'gh pr view 137' "pass"
+run_case "pr merge (not review)" 'gh pr merge 137' "pass"
+run_case "git commit -a (unrelated -a)" 'git commit -a -m msg' "pass"
+run_case "ls -a (unrelated -a)" 'ls -a' "pass"
+run_case "echo gh pr review (no approve token)" 'echo gh pr review' "pass"
+
+# --- Word-boundary guard cases (documented) ---
+echo "[Word-boundary guard — should pass through]"
+run_case "--approver should not match --approve" 'gh pr review 137 --approver someone' "pass"
+run_case "-abc should not match -a" 'gh pr review 137 -abc' "pass"
+
+# --- Fail-closed documented behavior: quoted --approve in --body ---
+echo "[Fail-closed — quoted --approve inside --body deny by design]"
+run_case "--body contains literal --approve text" 'gh pr review 137 --comment --body "please --approve later"' "deny"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if ((FAIL > 0)); then
+  printf '\n'
+  printf 'Failures:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -149,6 +149,17 @@
       {
         "hooks": [
           {
+            "command": "bash \"$HOME/.claude/hooks/pretool-gh-pr-self-approve-guard.sh\"",
+            "statusMessage": "PR self-approve チェック中...",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
             "command": "bash \"$HOME/.claude/hooks/generate-worktreeinclude.sh\"",
             "if": "Bash(git worktree add*)",
             "statusMessage": ".worktreeinclude 自動生成チェック中...",

--- a/tests/cli-packages.test.sh
+++ b/tests/cli-packages.test.sh
@@ -40,33 +40,25 @@ echo ""
 echo "--- tier-1: static text verification (no nix required) ---"
 
 # ---------------------------------------------------------------------------
-# tier-1 (1): containerOnly list must include nodejs_24
+# tier-1 (1): the (single, host-only) package list must NOT include nodejs*
+# (PATH collision guard; Node.js is managed by mise, "node = lts")
+#
+# NOTE: commit 21b56f2 (hermes repo separation) intentionally removed the
+# mode = "host" / "container" split from lib/cli-packages.nix — the
+# container-only list (incl. nodejs_24 for the hermes-agent Docker image)
+# now lives and evolves independently in the hermes repo. flake.nix's
+# hermes-image build target was removed in the same commit, so this repo no
+# longer has a "container mode" to test. The former
+# static_containerOnly_includes_nodejs_24 assertion is obsolete and removed;
+# the PATH-collision regression guard below is preserved against the
+# current flat list.
 # ---------------------------------------------------------------------------
-echo "- static_containerOnly_includes_nodejs_24"
-if awk '/^  containerOnly = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +nodejs_24$'; then
-  pass "static_containerOnly_includes_nodejs_24"
+echo "- static_hostList_excludes_nodejs"
+if grep -qE '^ +nodejs' "${REPO_ROOT}/lib/cli-packages.nix"; then
+  fail "static_hostList_excludes_nodejs" \
+    "'nodejs*' must NOT appear in ${REPO_ROOT}/lib/cli-packages.nix (managed by mise)"
 else
-  fail "static_containerOnly_includes_nodejs_24" \
-    "Expected 'nodejs_24' inside the containerOnly list in ${REPO_ROOT}/lib/cli-packages.nix"
-fi
-
-# ---------------------------------------------------------------------------
-# tier-1 (2): common / hostOnly lists must NOT include nodejs*
-# (host mode = common ++ hostOnly, so absence in both proves nodejs is
-#  excluded from host mode; PATH collision guard, Node.js is managed by mise)
-# ---------------------------------------------------------------------------
-echo "- static_hostSets_exclude_nodejs"
-if awk '/^  common = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +nodejs'; then
-  fail "static_hostSets_exclude_nodejs" \
-    "'nodejs*' must NOT appear in the common list of ${REPO_ROOT}/lib/cli-packages.nix"
-elif awk '/^  hostOnly = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +nodejs'; then
-  fail "static_hostSets_exclude_nodejs" \
-    "'nodejs*' must NOT appear in the hostOnly list of ${REPO_ROOT}/lib/cli-packages.nix"
-else
-  pass "static_hostSets_exclude_nodejs"
+  pass "static_hostList_excludes_nodejs"
 fi
 
 echo ""
@@ -80,7 +72,6 @@ echo "--- tier-2: nix eval verification (requires nix daemon) ---"
 # 評価する。これにより CI / 開発環境で評価結果が一致する。
 # ---------------------------------------------------------------------------
 eval_pkg_names() {
-  local mode="$1"
   local system
   system="$(nix eval --impure --raw --expr 'builtins.currentSystem' 2>/dev/null || true)"
   nix eval --json --impure --expr "
@@ -92,7 +83,7 @@ eval_pkg_names() {
       };
     in
       map (p: p.pname or p.name) (
-        import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; mode = \"${mode}\"; }
+        import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; }
       )
   " 2>/dev/null
 }
@@ -105,59 +96,32 @@ fi
 
 if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # -------------------------------------------------------------------------
-  # AC1: container mode must include nodejs_24
+  # PATH collision guard: the package list must NOT include nodejs
+  # (Node.js is managed by mise, "node = lts")
   # -------------------------------------------------------------------------
-  echo "- eval_containerMode_includes_nodejs_24"
-  container_pkgs="$(eval_pkg_names "container" || true)"
-  if echo "${container_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length > 0' >/dev/null 2>&1; then
-    pass "eval_containerMode_includes_nodejs_24"
-  else
-    fail "eval_containerMode_includes_nodejs_24" \
-      "Expected nodejs* in container mode packages, got: ${container_pkgs}"
-  fi
-
-  # -------------------------------------------------------------------------
-  # AC1 supplement: host mode must NOT include nodejs (PATH collision guard)
-  # -------------------------------------------------------------------------
-  echo "- eval_hostMode_unchanged_no_nodejs_in_cli_packages"
-  host_pkgs="$(eval_pkg_names "host" || true)"
+  echo "- eval_hostList_excludes_nodejs"
+  host_pkgs="$(eval_pkg_names || true)"
   if echo "${host_pkgs}" | jq -e 'map(select(startswith("nodejs"))) | length == 0' >/dev/null 2>&1; then
-    pass "eval_hostMode_unchanged_no_nodejs_in_cli_packages"
+    pass "eval_hostList_excludes_nodejs"
   else
-    fail "eval_hostMode_unchanged_no_nodejs_in_cli_packages" \
-      "nodejs must NOT appear in host mode (managed by mise). Got: ${host_pkgs}"
+    fail "eval_hostList_excludes_nodejs" \
+      "nodejs must NOT appear in cli-packages.nix (managed by mise). Got: ${host_pkgs}"
   fi
   # -------------------------------------------------------------------------
-  # AC: host mode must include hunk (git diff review TUI)
+  # AC: package list must include hunk (git diff review TUI)
   # upstream pname is "hunkdiff" (binary is bin/hunk), so use a prefix match.
   # -------------------------------------------------------------------------
-  echo "- hostMode_includes_hunk"
+  echo "- hostList_includes_hunk"
   if echo "${host_pkgs}" | jq -e 'map(select(startswith("hunk"))) | length > 0' >/dev/null 2>&1; then
-    pass "hostMode_includes_hunk"
+    pass "hostList_includes_hunk"
   else
-    fail "hostMode_includes_hunk" \
-      "Expected hunk* in host mode packages, got: ${host_pkgs}"
-  fi
-
-  # -------------------------------------------------------------------------
-  # AC: container mode must NOT include hunk (host-only, not needed in
-  # hermes-agent container image)
-  # -------------------------------------------------------------------------
-  echo "- containerMode_excludes_hunk"
-  if echo "${container_pkgs}" | jq -e 'map(select(startswith("hunk"))) | length == 0' >/dev/null 2>&1; then
-    pass "containerMode_excludes_hunk"
-  else
-    fail "containerMode_excludes_hunk" \
-      "hunk must NOT appear in container mode (host-only tool). Got: ${container_pkgs}"
+    fail "hostList_includes_hunk" \
+      "Expected hunk* in cli-packages.nix, got: ${host_pkgs}"
   fi
 else
-  skip "eval_containerMode_includes_nodejs_24" \
+  skip "eval_hostList_excludes_nodejs" \
     "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
-  skip "eval_hostMode_unchanged_no_nodejs_in_cli_packages" \
-    "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
-  skip "hostMode_includes_hunk" \
-    "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
-  skip "containerMode_excludes_hunk" \
+  skip "hostList_includes_hunk" \
     "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
 fi
 

--- a/tests/herdr-config.test.sh
+++ b/tests/herdr-config.test.sh
@@ -44,33 +44,24 @@ echo ""
 echo "--- tier-1: static text verification (no nix required) ---"
 
 # ---------------------------------------------------------------------------
-# tier-1 (1): hostOnly list in lib/cli-packages.nix includes herdr
+# tier-1 (1): the (single, host-only) package list in lib/cli-packages.nix
+# includes herdr.
+#
+# NOTE: commit 21b56f2 (hermes repo separation) intentionally removed the
+# mode = "host" / "container" split from lib/cli-packages.nix — this repo's
+# list is now a single flat (host-only) list, and flake.nix's hermes-image
+# container build target was removed in the same commit. The former
+# static_hostOnly_includes_herdr (block-scoped) and
+# static_containerSets_exclude_herdr assertions targeted the removed
+# common/hostOnly/containerOnly block structure and are obsolete; replaced
+# with a single presence check against the current flat list.
 # ---------------------------------------------------------------------------
-echo "- static_hostOnly_includes_herdr"
-if awk '/^  hostOnly = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +herdr$'; then
-  pass "static_hostOnly_includes_herdr"
+echo "- static_list_includes_herdr"
+if grep -qE '^ +herdr$' "${REPO_ROOT}/lib/cli-packages.nix"; then
+  pass "static_list_includes_herdr"
 else
-  fail "static_hostOnly_includes_herdr" \
-    "Expected 'herdr' inside the hostOnly list in ${REPO_ROOT}/lib/cli-packages.nix"
-fi
-
-# ---------------------------------------------------------------------------
-# tier-1 (2): common / containerOnly lists must NOT include herdr
-# (container mode = common ++ containerOnly, so absence in both proves
-#  herdr is excluded from container images)
-# ---------------------------------------------------------------------------
-echo "- static_containerSets_exclude_herdr"
-if awk '/^  common = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +herdr$'; then
-  fail "static_containerSets_exclude_herdr" \
-    "'herdr' must NOT appear in the common list of ${REPO_ROOT}/lib/cli-packages.nix"
-elif awk '/^  containerOnly = with pkgs; \[/,/^  \];/' "${REPO_ROOT}/lib/cli-packages.nix" |
-  grep -qE '^ +herdr$'; then
-  fail "static_containerSets_exclude_herdr" \
-    "'herdr' must NOT appear in the containerOnly list of ${REPO_ROOT}/lib/cli-packages.nix"
-else
-  pass "static_containerSets_exclude_herdr"
+  fail "static_list_includes_herdr" \
+    "Expected 'herdr' inside ${REPO_ROOT}/lib/cli-packages.nix"
 fi
 
 # ---------------------------------------------------------------------------
@@ -193,7 +184,6 @@ echo "--- tier-2: nix eval verification (requires nix daemon) ---"
 # 評価する。これにより CI / 開発環境で評価結果が一致する。
 # ---------------------------------------------------------------------------
 eval_pkg_names() {
-  local mode="$1"
   local system
   system="$(nix eval --impure --raw --expr 'builtins.currentSystem' 2>/dev/null || true)"
   nix eval --json --impure --expr "
@@ -202,7 +192,7 @@ eval_pkg_names() {
       pkgs = flake.inputs.nixpkgs.legacyPackages.${system};
     in
       map (p: p.pname or p.name) (
-        import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; mode = \"${mode}\"; }
+        import ${REPO_ROOT}/lib/cli-packages.nix { inherit pkgs; }
       )
   " 2>/dev/null
 }
@@ -215,31 +205,19 @@ fi
 
 if [ "${NIX_AVAILABLE}" -eq 1 ]; then
   # -------------------------------------------------------------------------
-  # tier-2 (a): host mode must include herdr
+  # tier-2 (a): package list must include herdr
   # -------------------------------------------------------------------------
-  echo "- eval_hostMode_includes_herdr"
-  host_pkgs="$(eval_pkg_names "host" || true)"
+  echo "- eval_list_includes_herdr"
+  host_pkgs="$(eval_pkg_names || true)"
   if echo "${host_pkgs}" | jq -e 'map(select(. == "herdr")) | length > 0' >/dev/null 2>&1; then
-    pass "eval_hostMode_includes_herdr"
+    pass "eval_list_includes_herdr"
   else
-    fail "eval_hostMode_includes_herdr" \
-      "Expected herdr in host mode packages, got: ${host_pkgs}"
+    fail "eval_list_includes_herdr" \
+      "Expected herdr in cli-packages.nix, got: ${host_pkgs}"
   fi
 
   # -------------------------------------------------------------------------
-  # tier-2 (b): container mode must NOT include herdr (hostOnly, not needed in image)
-  # -------------------------------------------------------------------------
-  echo "- eval_containerMode_excludes_herdr"
-  container_pkgs="$(eval_pkg_names "container" || true)"
-  if echo "${container_pkgs}" | jq -e 'map(select(. == "herdr")) | length == 0' >/dev/null 2>&1; then
-    pass "eval_containerMode_excludes_herdr"
-  else
-    fail "eval_containerMode_excludes_herdr" \
-      "herdr must NOT appear in container mode (hostOnly). Got: ${container_pkgs}"
-  fi
-
-  # -------------------------------------------------------------------------
-  # tier-2 (c): home.file ".config/herdr" is wired with recursive = true
+  # tier-2 (b): home.file ".config/herdr" is wired with recursive = true
   # -------------------------------------------------------------------------
   echo "- eval_homeFile_herdr_recursive_true"
   herdr_recursive="$(nix eval --json --impure --expr "
@@ -255,9 +233,7 @@ if [ "${NIX_AVAILABLE}" -eq 1 ]; then
       "Expected homeConfigurations.\"naramotoyuuji-darwin\".config.home.file.\".config/herdr\".recursive == true, got: ${herdr_recursive}"
   fi
 else
-  skip "eval_hostMode_includes_herdr" \
-    "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
-  skip "eval_containerMode_excludes_herdr" \
+  skip "eval_list_includes_herdr" \
     "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"
   skip "eval_homeFile_herdr_recursive_true" \
     "nix daemon unreachable (sandboxed environment) — run outside sandbox for full verification"


### PR DESCRIPTION
## 概要

Closes #137

`gh pr review --approve` によるセルフ承認を、決定論的な PreToolUse hook で deny する。「merge/approve は常に人間が行う」invariant を、プロンプト指示だけに頼らず hook レベルで強制する。

## 動機

`/dev-flow 432` → `pr-iterate 434` の run で、post-summary stage の subagent が `gh pr review 434 --approve` を実行しようとした（harness の安全分類器が検知して未遂に終わったが、意図的な試行だった）。GitHub 側の制約（自分の PR には approve できない）に救われただけで、dev-flow 側には何の抑止もなかった。指示文の強化だけでは不十分なため、決定論的な排除策として本 hook を追加する。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `claude-code/hooks/pretool-gh-pr-self-approve-guard.sh` | 新規。`gh ... pr review ...` 呼び出しに standalone token として `--approve`/`-a` が含まれる場合を検出し deny する PreToolUse(Bash) hook。compound command・グローバルフラグ挟み込みにも対応し、引用文字列内の誤検知は安全側（fail-closed）で deny する |
| `claude-code/hooks/pretool-gh-pr-self-approve-guard.test.sh` | 新規。上記 hook のテスト |
| `claude-code/settings.json` | PreToolUse(Bash) hook 一覧に本 hook を登録 |
| `claude-code/README.md` | フック一覧表に本 hook のエントリを追加 |
| `tests/cli-packages.test.sh` | 既存テストの整理・簡素化 |
| `tests/herdr-config.test.sh` | 既存テストの整理・簡素化 |

## テスト計画

- [x] `pretool-gh-pr-self-approve-guard.test.sh` によるユニットテスト
- [x] `gh pr review 137 --approve` / `gh pr review 137 -a` 等の deny を確認
- [x] `gh pr review 137 --comment` / `gh pr merge 137` 等、非対象コマンドの素通しを確認
