### PR TITLE
fix(sandbox): nix を sandbox 内で実行可能にし、誤った tmp/worktree 案内を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Pre-commit hook (treefmt + shellcheck) auto-installs via `nix develop`.
 
 Always run `nix run .#update` after changes.
 
+> **agent 実行時の注意**: `nix run .#update` は内部で `sudo darwin-rebuild` を呼ぶため sandbox/permission で拒否される。**apply は人間が実行**し、agent は `nix fmt` / `nix flake check` / `nix eval` までを検証範囲とする。
+
 ## Critical Notes
 
 - **大西配列**: Navigation keys are `tnrs` (not `hjkl`) across Neovim, zellij, etc.

--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -50,7 +50,9 @@ Conflict: Safety > Scope > Quality > Speed
 
 ## Sandbox Hygiene
 🟡 sandbox 有効時（bg/remote 含む）に多発する失敗をコマンド側で回避する:
-- **一時ファイルは `/tmp` 直書き禁止**。`$TMPDIR`（bg では `$CLAUDE_JOB_DIR/tmp`）を使う。素の `/tmp/foo` は書込み不許可で `Operation not permitted`
+- **一時ファイルは `/tmp` 直書き禁止**。bg/remote を含め常に `$TMPDIR` を使う。素の `/tmp/foo` は書込み不許可で `Operation not permitted`
+  - `$CLAUDE_JOB_DIR/tmp` は使わない。`~/.claude/jobs` は Claude Code 組み込みの自己改変ガードで write deny されており、`sandbox.filesystem.allowWrite` に書いても上書きできない（deny が allow 内で優先される）。bg セッションの system prompt は `$CLAUDE_JOB_DIR/tmp` を案内するが実際には書けない
+- **`~/.claude/skills` / `~/.claude/agents` の実体（`it-all-playpark/skills` repo）は repo 丸ごと write deny**。組み込みの自己改変ガードが symlink を解決して効くため、repo 内の `.claude/worktrees/` も書けない。skills repo を編集する作業は **repo 外**に worktree を切る（例: `git worktree add ~/ghq/github.com/it-all-playpark/skills-wt/<branch>`）。settings では緩められない
 - **process substitution `<(…)` を避ける**。`diff <(a) <(b)` 等は sandbox が `/dev/fd/*` を塞ぐため失敗する。一旦 tempfile に落として `diff f1 f2` にする
 - **network は `sandbox.network.allowedDomains` のホストのみ**到達可能。未許可ホストは即失敗 → 必要なら settings.json に追加してから実行（推測で叩かない）
 - sandbox で塞がれても `dangerouslyDisableSandbox` は policy で無効。回避不能なら失敗を報告し、settings 調整を提案する（勝手に緩めない）

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -541,6 +541,8 @@
     "failIfUnavailable": true,
     "filesystem": {
       "allowWrite": [
+        "~/.cache/nix",
+        "~/.local/state/nix",
         "~/.claude/journal",
         "~/.claude/logs",
         "~/.claude/memory",


### PR DESCRIPTION
## 背景

sandbox 有効下で agent の作業が頻繁に拒否される件の実データ調査。`~/.claude/projects/**/*.jsonl`（580MB / 3,264 セッション）から `Operation not permitted` を集計し、再現プローブで裏を取った。

## 修正内容

### 1. nix が sandbox 内で完全に死んでいた（最大の実害）

`~/.cache/nix` が write deny のため fetcher-cache の SQLite が開けず、**`nix flake metadata` すら失敗**していた。

```
error: executing SQLite statement 'pragma synchronous = off':
unable to open database file (in '~/.cache/nix/fetcher-cache-v4.sqlite')
```

本 repo は CLAUDE.md で `nix fmt` / `nix flake check` を必須としているのに agent が一切実行できない状態だった（transcript 上の denial context: nix 関連で計 ~400 箇所）。

→ `sandbox.filesystem.allowWrite` に `~/.cache/nix` と `~/.local/state/nix` を追加。

**セキュリティ評価**: どちらも cache/state ディレクトリ。`/nix/store` は root 所有かつ immutable、ビルドは nix-daemon(root) 側で行われるため、この 2 パスへの書き込みで権限昇格やコード実行の経路は増えない。`sudo darwin-rebuild` を伴う `nix run .#update` は従来どおり deny のまま（apply は人間）。

### 2. `$CLAUDE_JOB_DIR/tmp` が実際には使えない

`~/.claude/jobs` は Claude Code 組み込みの自己改変ガードで write deny されており、`allowWrite` に列挙済みなのに `touch` が `Operation not permitted`（deny が allow 内で優先されるため設定で上書き不可）。bg セッションの system prompt はこのパスを案内してくるが書けない。

→ RULES.md を「bg/remote 含め常に `$TMPDIR`」に修正。

### 3. skills repo 全体が write deny

`~/.claude/skills` → `it-all-playpark/skills` の symlink を組み込みガードが解決するため、**repo 丸ごと**（`.claude/worktrees/` 配下も含む）書き込み不可。dev-flow の implementer が繰り返しここで BLOCKED になっていた（transcript 上 595 箇所）。settings では緩められない。

→ RULES.md に「skills repo を触る作業は repo **外**に worktree を切る」を明記。

## 検証

- [x] `jq -e` で settings.json の JSON 妥当性を確認
- [x] 各 deny を実プローブで再現（nix cache / skills repo / `~/.claude/jobs`）
- [x] repo 外パス（`~/ghq/github.com/it-all-playpark/` 直下）が書き込み可能なことを確認
- [ ] `nix fmt` / `nix flake check` — **未実行**。treefmt は `nix develop` 経由でしか入らず、その nix が本 PR で直そうとしている当の問題で動かないため。設定適用後に人間側で実行を推奨
- [ ] 設定適用後の nix 動作確認 — settings 変更は再起動後に有効になるため本セッションでは検証不能

## 適用手順

settings.json は sandbox の deny 対象で agent からは直接書けないため、この PR をマージ後に人間側で反映してください。