### PR TITLE
docs: ✏️ dev を保護ブランチとして明記し hook と整合させる

### DIFF
--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -65,7 +65,9 @@ Conflict: Safety > Scope > Quality > Speed
 - **Deletion**: `rip` を使用（復元可能）
 
 ## Git
-- Feature branch で作業。`dev` branch は直接 push 可
+- Feature branch で作業。**保護ブランチへの直接 push は禁止**（`main` / `master` / `dev` / `develop` / `development` / `production` / `staging` / `release` / `nightly`）— `dev` も含めて必ず PR 経由。CI とレビューを飛ばさないため
+  - 強制は `allow-feature-push.sh`（PreToolUse hook）が主。`main` / `master` / `dev` / `develop` / `development` は `permissions.deny` でも重ねて塞いである
+  - `保護/デプロイブランチ (...) への push は禁止` で止まったら sandbox ではなくこの hook。feature branch を切って PR を出す
 - Incremental commits with descriptive messages
 
 ## Temporal Awareness


### PR DESCRIPTION
## 背景

`shift-bud` で `git push origin dev` が止められ「sandbox に弾かれた」と誤認された。実際に出していたのは sandbox ではなく PreToolUse hook `allow-feature-push.sh` の `保護/デプロイブランチ (dev) への push は禁止`。同セッションの feature branch への push は成功している。

原因は設定の自己矛盾:

- `RULES.md`: 「`dev` branch は直接 push 可」
- `allow-feature-push.sh` の `is_protected()`: `dev` を保護対象に含む
- `permissions.deny`: `dev` 宛の push エントリが 8 件

## 変更

hook 側（PR 経由を強制）を正として `RULES.md` を修正。dev への直 push は CI とレビューを飛ばすため、保護を維持する方針。

あわせて「このメッセージで止まったら sandbox ではなく hook」という切り分けを書き添えた（今回の誤認の再発防止）。

## 検証

- `nix fmt` → 76 files, 0 changed（フォーマット変化なし）
- deny エントリの実測: push 系 deny がカバーするのは `main`/`master`/`dev`/`develop`/`development` の 5 つのみ。`production`/`staging`/`release`/`nightly` は hook のみでの保護 — 本文はこの実態に合わせて記述している

ドキュメントのみの変更で、hook・settings.json には手を入れていない。