### PR TITLE
fix(deskflow): 🐛 cask を deskflow-dev に変更しカーソル固着を解消する

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -82,7 +82,14 @@ in
       "chatgpt"
       "claude"
       "deepl"
-      "deskflow/tap/deskflow" # Mac間でキーボード・マウスを共有するソフトウェアKVM
+      # Mac間でキーボード・マウスを共有するソフトウェアKVM。
+      # 安定版 (deskflow) ではなく master 追従の deskflow-dev を使う。macOS サーバーで
+      # ホットキー切替後にカーソルが固まる問題の修正 (deskflow/deskflow#9784, #9963) が
+      # v1.26.0 に入っておらず、continuous ビルドにしか存在しないため。
+      # 詳細と安定版へ戻す手順: home-manager/home/file/deskflow/README.md
+      # 両 cask は conflicts_with なので、切り替え時は先に
+      # `brew uninstall --cask deskflow` を実行してから apply すること。
+      "deskflow/tap/deskflow-dev"
       "font-hack-nerd-font"
       "google-chrome"
       "google-drive"

--- a/home-manager/home/file/deskflow/README.md
+++ b/home-manager/home/file/deskflow/README.md
@@ -1,7 +1,8 @@
 # Deskflow server config
 
 Mac 間でキーボード・マウスを共有する Deskflow のサーバ設定 (`deskflow-server.conf`)。
-アプリ本体は `darwin/default.nix` の Homebrew cask で導入している。
+アプリ本体は `darwin/default.nix` の Homebrew cask で導入している。cask は安定版の
+`deskflow` ではなく master 追従の **`deskflow-dev`**（→「カーソル固着」の節）。
 
 配置先は `~/.config/deskflow/deskflow-server.conf`（home-manager の read-only symlink）。
 
@@ -81,15 +82,42 @@ ZMK キーボード (`zmk-config-fish`) の `layer_navi` から出している�
 F13/F14 は英数字の範囲外なので、macOS システムホットキー・ghostty・zellij・
 Raycast のいずれとも原理的に衝突しない。
 
-## 既知の未解決バグ（upstream）
+## ホットキー切替後にカーソルが固まる件（upstream 修正済み / cask を dev にした理由）
 
-`OSXScreen::leave()` がカーソルを画面中央に warp せず `m_xCursor`/`m_yCursor` を
-更新しないため、baseline が stale になる（deskflow/deskflow#9779、open）。
-`MSWindowsScreen::leave()` と `XWindowsScreen::leave()` は両方 warp するので
-**macOS サーバーだけの欠陥**。ホットキー切替で発火し、エッジ切替では起きない。
+v1.26.0 の `OSXScreen::leave()` はカーソルを画面中央へ warp せず `m_xCursor` /
+`m_yCursor` も更新しない。一方 `onMouseMove()` の secondary 側は「今の実座標 −
+`m_xCursor`」で移動量を出すため、切替直後の 1 発目が巨大な delta になり
+`bogusZoneSize` のフィルタに落ちて捨てられる。さらに v1.26.0 は移動イベントを
+`return event` でローカルにも流したうえで毎回カーソルを中央へ warp し続けるので、
+**トラックパッドは動いているのにサーバー側のカーソルが中央に貼り付いて動かない**
+ように見える。
 
-サーバー側でカーソルが動かなくなる症状はこれが原因の可能性がある。修飾キーの
-stuck とは独立した問題なので、F13/F14 化しても残るなら upstream 修正が必要。
+エッジ切替では warp サイクルが途切れず baseline が同期されたままなので発火しない。
+つまり**ホットキー切替に固有の症状**で、F13/F14 化（修飾キー stuck の対策）とは
+独立した問題。
+
+upstream では 2 本の PR で解消済み:
+
+| PR | 内容 | merge |
+| --- | --- | --- |
+| [#9784](https://github.com/deskflow/deskflow/pull/9784) | `leave()` でカーソルを中央へ warp し baseline を同期（[#9779](https://github.com/deskflow/deskflow/issues/9779) の修正） | 2026-06-01 |
+| [#9963](https://github.com/deskflow/deskflow/pull/9963) | `leave()` で `CGAssociateMouseAndMouseCursorPosition(false)` によりマウスを capture し、client 制御中は `kCGMouseEventDeltaX/Y` の生 delta を読む。移動イベントはローカルへ流さず消費し、`enter()` で再結合 | 2026-07-18 |
+
+**どちらも v1.26.0（2026-02-16 リリース）には入っていない**。安定版の次リリースを
+待つ代わりに、公式 tap の `deskflow-dev`（`continuous` = master ビルドを追う cask）
+へ切り替えている。
+
+### 安定版へ戻す場合
+
+`darwin/default.nix` の cask を `deskflow/tap/deskflow` に戻し、apply 前に
+`brew uninstall --cask deskflow-dev` を実行する（両 cask は `conflicts_with`）。
+逆方向へ切り替えるときも同様に、先に旧 cask を uninstall しておくこと。
+
+### 別件（未修正・低頻度）
+
+`AppUtilUnix::getCurrentLanguageCode()` が `CFArrayGetCount(layoutLanguages) &&
+layoutLanguages` と NULL チェックを後置しており SIGSEGV しうる。キーダウン毎に
+呼ばれるが実測で数日に 1 回程度。上記のカーソル固着とは別件。
 
 ## 編集時の注意
 


### PR DESCRIPTION
## 課題

Deskflow の macOS サーバー (Mac Studio) で、**ホットキー切替後にカーソルが動かなくなる**。
F13/F14 化で修飾キー stuck は解消したが、こちらは独立した問題として残っていた。

## 原因

v1.26.0 の `OSXScreen::leave()` はカーソルを画面中央へ warp せず `m_xCursor` / `m_yCursor` も更新しない。
`onMouseMove()` の secondary 側は「実座標 − `m_xCursor`」で delta を出すため、切替直後の 1 発目が巨大値になり `bogusZoneSize` フィルタに落ちて捨てられる。
さらに v1.26.0 は移動イベントを `return event` でローカルにも流したうえで毎回カーソルを中央へ warp し続けるので、**トラックパッドは動いているのにカーソルが中央に貼り付いて動かない**ように見える。

エッジ切替では warp サイクルが途切れず baseline が同期されたままなので発火しない = **ホットキー切替に固有**。

## upstream の修正

| PR | 内容 | merge |
| --- | --- | --- |
| [#9784](https://github.com/deskflow/deskflow/pull/9784) | `leave()` で中央へ warp し baseline を同期（[#9779](https://github.com/deskflow/deskflow/issues/9779) をクローズ） | 2026-06-01 |
| [#9963](https://github.com/deskflow/deskflow/pull/9963) | `leave()` で mouse capture、client 制御中は `kCGMouseEventDeltaX/Y` の生 delta を使用、移動イベントをローカルへ流さず `enter()` で再結合 | 2026-07-18 |

どちらも **v1.26.0 (2026-02-16 リリース) には未収録**で、`continuous` ビルドにのみ存在する。

## 変更

- `darwin/default.nix`: cask を `deskflow/tap/deskflow` → `deskflow/tap/deskflow-dev`（公式 tap の `continuous` = master 追従 cask）
- `home-manager/home/file/deskflow/README.md`: 「既知の未解決バグ」節を原因・修正 PR・安定版へ戻す手順に差し替え

conf (`deskflow-server.conf`) は変更なし。

## apply 手順（手動）

両 cask は `conflicts_with` のため、**先に旧 cask を消してから** apply する。

```bash
brew uninstall --cask deskflow
nix run .#update
```

サーバー (Mac Studio) 側の修正だが、cask 定義は共通なので client (MacBook Pro) も同時に更新される。

## 検証

- `nix-instantiate --parse darwin/default.nix` → OK
- `nix fmt` / `nix flake check` は sandbox から nix daemon socket へ接続できず未実行。インデントは既存リスト要素と同じ 6 スペースで揃えてある
- 実機での効果確認は apply 後に人間が実施