### PR TITLE
fix(homebrew): 🐛 deskflow/tap を tap 単位で trust し activation 失敗を解消する

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -59,8 +59,20 @@ in
       extraFlags = [ "--force-cleanup" ]; # cleanup実行時の確認を明示的に許可
     };
     taps = [
-      "deskflow/tap" # Deskflow公式Homebrew tap
-      "rjyo/moshi" # moshi-hook 配布用 tap
+      {
+        # Deskflow公式Homebrew tap。
+        # cask 単位ではなく tap 単位で trust する必要がある: activation 末尾の
+        # `brew cleanup` は tap 内の *全* cask をロードするが、この tap には Brewfile に
+        # 載せていない安定版 `deskflow` cask も含まれる。Brewfile 由来の trust は
+        # `deskflow/tap/deskflow-dev` しか登録しないため、trust されていない
+        # `deskflow` に当たって
+        #   Error: Refusing to load cask deskflow/tap/deskflow from untrusted tap
+        # となり `brew cleanup` が exit 1 → activation 全体が失敗する
+        # (Homebrew 6.0.0 で HOMEBREW_REQUIRE_TAP_TRUST がデフォルト有効化された影響)。
+        name = "deskflow/tap";
+        trusted = true;
+      }
+      "rjyo/moshi" # moshi-hook 配布用 tap (formula は moshi-hook のみで、完全修飾名により trust 済み)
     ];
     brews = [
       {

--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -55,8 +55,9 @@ in
       # Homebrew有効化時の挙動設定
       autoUpdate = true; # brewの自動更新を有効化
       upgrade = true; # 古いバージョンがあれば自動でアップグレード
-      cleanup = "uninstall"; # Brewfileにないものをアンインストール
-      extraFlags = [ "--force-cleanup" ]; # cleanup実行時の確認を明示的に許可
+      # Brewfileにないものをアンインストール。
+      # nix-darwin が `--force-cleanup` を自動で付けるので extraFlags での指定は不要
+      cleanup = "uninstall";
     };
     taps = [
       {


### PR DESCRIPTION
## 症状

`nix run .#update naramotoyuuji` が最後に失敗する:

```
`brew bundle` complete! 38 Brewfile dependencies now installed.
Error: Failure while executing; `/opt/homebrew/bin/brew cleanup` exited with 1.
```

## 根本原因

`brew cleanup --dry-run` を単体実行して原因を特定した:

```
Error: Refusing to load cask deskflow/tap/deskflow from untrusted tap deskflow/tap.
Run `brew trust --cask deskflow/tap/deskflow` or `brew trust deskflow/tap` to trust it.
```

- Homebrew 6.0.0 で `HOMEBREW_REQUIRE_TAP_TRUST` がデフォルト有効化され、非公式 tap の formula/cask は trust されていないとロードが拒否される
- `brew cleanup` は tap 内の **全** cask をロードする
- `deskflow/tap` には `deskflow-dev.rb` と `deskflow.rb`（安定版）の 2 つがあるが、Brewfile に載せているのは `deskflow-dev` のみ
- Brewfile 由来の trust は完全修飾名の cask だけを登録する（`~/.homebrew/trust.json` は `deskflow/tap/deskflow-dev` のみ）
- → trust されていない `deskflow` に当たって cleanup が exit 1

手動 `brew trust deskflow/tap` は activation のたびに Brewfile 由来の trust で上書きされるので恒久策にならない。

## 修正

### 1. `deskflow/tap` を tap 単位で trust する（本命）

nix-darwin の `homebrew.taps.*.trusted` オプション（`modules/homebrew.nix`）で tap 単位の trust を宣言し、Brewfile に `tap "deskflow/tap", trusted: true` を出力させる。

`rjyo/moshi` は formula が `moshi-hook` 1 つだけで、完全修飾名により trust 済みのため変更不要。

### 2. 冗長な `extraFlags` を削除する

nix-darwin は `onActivation.cleanup = "uninstall"` から `--force-cleanup` を自動生成する:

```nix
++ optional (config.cleanup == "uninstall") "--force-cleanup"
++ optional (config.cleanup == "zap") "--zap --force-cleanup"
++ config.extraFlags
```

そのため `extraFlags = [ "--force-cleanup" ]` は重複しており、生成される activate スクリプトは同じフラグを 2 回渡していた:

```
brew bundle --file='...' --force-cleanup --force-cleanup
```

削除後も cleanup オプション由来の `--force-cleanup` が 1 つ残るため挙動は変わらない。

## 検証

- tap trust の要求のみを一時的に外して dry-run すると **exit 0** で完走 → cleanup の失敗要因は trust 以外に無いと実証（詳細は下のコメント。`HOMEBREW_NO_REQUIRE_TAP_TRUST` は検証専用で、回避策としては採らない）
- `nix-instantiate --parse darwin/default.nix` → OK
- `nix fmt` / `nix flake check` は sandbox が nix daemon socket を塞いでいるため実行できず、CI に委ねる。既存の `brews` ブロックと同一の attrset 構造にしてある
- **apply（`nix run .#update`）は未実行**。sudo を伴うため人間の実行が必要

## 別件（この PR のスコープ外）

`deskflow-dev` は `continuous` タグを追う cask で、1 日に数回 sha256 が変わる。`upgrade = true` と組み合わさっているため apply のたびに 29MB の再ダウンロードが走り、tap の更新タイミング次第で checksum mismatch も再発しうる。Brewfile から外して手動管理にするかは別途判断する。
