### PR TITLE
fix(deskflow): 🐛 サーバ設定を実体コピーで置き nix store パス焼き込みを防ぐ

### DIFF
--- a/home-manager/home/default.nix
+++ b/home-manager/home/default.nix
@@ -95,18 +95,35 @@ in
     # ロック対象も -xn で扱える)。
     packages = packages.commonPackages ++ cliPackages ++ [ pkgs.flock ];
 
+    # Deskflow (ソフトウェアKVM) のサーバ設定。GUI の Server タブで「外部設定ファイルを
+    # 使う」を有効にし ~/.config/deskflow/deskflow-server.conf を指定する。
+    #
+    # home.file の symlink ではなく実体コピーで置く。Deskflow の GUI は選択されたパスを
+    # 実体解決してから Deskflow.conf の externalConfigFile に記録するため、symlink だと
+    # /nix/store/<hash>-hm_deskflowserver.conf が焼き込まれる。conf を編集すると hash が
+    # 変わるので Deskflow は古い世代を読み続け (GC 後は読めなくなり) 編集が反映されない。
+    # 実体ファイルなら解決結果が指定パスと一致し、この経路が成立しない。
+    #
+    # 外部設定が有効な間 Deskflow はこのファイルを読むだけで書き戻さない
+    # (CoreProcess::persistServerConfig)。デフォルトの ~/Library/Deskflow/ 側は書き込み
+    # 可能のまま残すので、外部設定を切っても GUI が壊れない。
+    #
+    # linkGeneration は writeBoundary の後に走る (home-manager modules/files.nix)。この
+    # パスは以前 home.file 管理だったので、その撤去処理より後に置かないと消される。
+    activation.deskflowServerConfig = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+      deskflowConf="${config.home.homeDirectory}/.config/deskflow/deskflow-server.conf"
+      # 444 のまま install すると dest を開けず EACCES になるので先に消す。
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/rm -f "$deskflowConf"
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/install -D -m 444 \
+        ${./file/deskflow/deskflow-server.conf} "$deskflowConf"
+    '';
+
     file = {
       ".myclirc".source = ./file/.myclirc;
       ".ripgreprc".source = ./file/.ripgreprc;
       ".myclirc.local.template".source = ./file/.myclirc.local.template;
       ".config/git/config.local.template".source = ./file/git/config.local.template;
       ".config/fish/config.fish.local.template".source = ./file/fish/config.fish.local.template;
-      # Deskflow (ソフトウェアKVM) のサーバ設定。GUI の Server タブで「外部設定ファイル
-      # を使う」を有効にし、このパスを指定する。外部設定が有効な間 Deskflow はこのファイル
-      # を読むだけで書き戻さない (CoreProcess::persistServerConfig) ため、home-manager の
-      # read-only symlink で問題ない。デフォルトの ~/Library/Deskflow/ 側は書き込み可能の
-      # まま残すので、外部設定を切っても GUI が壊れない。
-      ".config/deskflow/deskflow-server.conf".source = ./file/deskflow/deskflow-server.conf;
       ".config/nvim" = {
         source = ./file/nvim;
         recursive = true;

--- a/home-manager/home/file/deskflow/README.md
+++ b/home-manager/home/file/deskflow/README.md
@@ -4,7 +4,9 @@ Mac 間でキーボード・マウスを共有する Deskflow のサーバ設定
 アプリ本体は `darwin/default.nix` の Homebrew cask で導入している。cask は安定版の
 `deskflow` ではなく master 追従の **`deskflow-dev`**（→「カーソル固着」の節）。
 
-配置先は `~/.config/deskflow/deskflow-server.conf`（home-manager の read-only symlink）。
+配置先は `~/.config/deskflow/deskflow-server.conf`。home-manager の symlink ではなく
+**activation script (`home.activation.deskflowServerConfig`) による実体コピー**（mode 444）。
+理由は「なぜ symlink ではなく実体コピーか」の節。
 
 ## 初回セットアップ（手動、1回だけ）
 
@@ -19,10 +21,35 @@ externalConfig=true
 externalConfigFile=/Users/<user>/.config/deskflow/deskflow-server.conf
 ```
 
+**`/nix/store/...` が入っていたら失敗**（→ 次節）。その場合は Deskflow を終了してから
+`Deskflow.conf` の `externalConfigFile` 行を上記のパスへ手で書き直す。Deskflow が起動中に
+編集すると、終了時の QSettings 書き戻しで消える。
+
 デフォルトの `~/Library/Deskflow/deskflow-server.conf` は書き込み可能なまま残してある。
 外部設定を無効に戻しても GUI が書き込みに失敗しない。
 
-## なぜ read-only symlink で平気か
+## なぜ symlink ではなく実体コピーか
+
+Deskflow の GUI はファイル選択ダイアログで選ばれたパスを**実体解決してから**
+`Deskflow.conf` の `externalConfigFile` に記録する。`~/.config/deskflow/deskflow-server.conf`
+が home-manager の symlink だと、記録されるのは
+
+```
+externalConfigFile=/nix/store/<hash>-hm_deskflowserver.conf
+```
+
+という**その時点の世代の store path** になる。この conf を編集すると hash が変わるが
+`Deskflow.conf` 側は古い hash を指したままなので、
+
+- Deskflow は**古い世代の conf を読み続ける**（編集が無反応に見える）
+- `nix-collect-garbage` 後は**パスごと消えて読めなくなる**
+
+`home.activation.deskflowServerConfig` で実体ファイルとして置けば解決結果が指定パスと
+一致するので、この経路が成立しない。activation は `entryAfter [ "linkGeneration" ]`
+（`writeBoundary` ではない）— このパスは以前 `home.file` 管理だったため、その撤去処理の
+後でないと消される。
+
+## なぜ read-only (mode 444) で平気か
 
 `CoreProcess::persistServerConfig()` は外部設定が有効なとき、パスと readable 判定を
 返すだけでファイルを書かない。内部設定モードのときだけデフォルトパスを


### PR DESCRIPTION
## 問題

`~/Library/Deskflow/Deskflow.conf` の `externalConfigFile` が nix store パスを指していた:

```ini
externalConfig=true
externalConfigFile=/nix/store/l0p865la6niin428bj95gq2zwn9jc65j-hm_deskflowserver.conf
```

Deskflow の GUI はファイル選択ダイアログのパスを**実体解決してから**記録するため、
`~/.config/deskflow/deskflow-server.conf` が home-manager の symlink だと、その時点の
世代の store path が焼き込まれる。

結果:

- conf を編集すると store hash が変わるが `Deskflow.conf` は古い hash を指したまま
  → **Deskflow は古い世代を読み続け、編集が反映されない**
- `nix-collect-garbage` 後は**パスごと消えて読めなくなる**

（今回は偶然、記録されていた store path が現行世代と一致していたため中身の実害は
出ていなかったが、次に conf を触った時点で踏む。）

## 変更

`home.file` の symlink をやめ、`home.activation.deskflowServerConfig` で
`~/.config/deskflow/deskflow-server.conf` に**実体コピー**（mode 444）を置く。
GUI の解決結果が指定パスと一致するので、store path が焼き込まれる経路が成立しない。

activation は `entryAfter [ "linkGeneration" ]`。`linkGeneration` は `writeBoundary`
の**後**に走る（home-manager `modules/files.nix:187`）ので、`writeBoundary` 指定だと
旧 `home.file` symlink の撤去処理に消される。

mode 444 のまま `install` すると dest を開けず EACCES になるため、事前に `rm -f` する。

read-only のままで平気な理由は既存 README の通り（`CoreProcess::persistServerConfig()`
は外部設定が有効な間このファイルへ書かない）。

## apply 後に必要な手動作業（1回だけ）

`Deskflow.conf` に焼き込まれた古い store path は自動では直らない。**Deskflow を終了してから**
`~/Library/Deskflow/Deskflow.conf` の該当行を書き直す（起動中に編集すると終了時の
QSettings 書き戻しで消える）:

```ini
externalConfigFile=/Users/naramotoyuuji/.config/deskflow/deskflow-server.conf
```

または GUI で選択し直す（実体ファイルになっているので今度は正しいパスが記録される）。

## 検証

- `nix fmt` / `nix flake check` → pass（`all checks passed!`）
- `nix-instantiate --parse home-manager/home/default.nix` → pass
- ⚠️ `nix eval` による darwinConfigurations の完全評価は**未実施**。途中から sandbox が
  nix daemon socket への接続を拒否するようになったため（`cannot connect to socket at
  '/nix/var/nix/daemon-socket/socket': Operation not permitted`）。
  `nix flake check` は `darwinConfigurations` を評価しないので、この確認は別途必要。
  apply 前に `nix eval '.#darwinConfigurations.naramotoyuuji.config.system.build.toplevel'`
  等で評価が通ることを確認してほしい。
- apply（`nix run .#update`）は `sudo darwin-rebuild` を呼ぶため未実行。

## 代替案（不採用）

`config.lib.file.mkOutOfStoreSymlink` で repo 内の conf を直接指す方法もある。世代非依存
かつ rebuild なしで編集が反映される利点があるが、`Deskflow.conf` に記録されるのは repo の
パスになり「`~/.config/` を指定したい」という要件を満たさない。
