### PR TITLE
feat: Tool Routing を hook で強制する context-guard を追加

### DIFF
--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -56,6 +56,7 @@ nix run .#update
 | `PreToolUse` Bash | `pretool-gh-pr-self-approve-guard.sh` | `gh pr review --approve` による PR self-approve を deny（merge/approve は常に人間） |
 | `PreToolUse` Bash (`git worktree add*`) | `generate-worktreeinclude.sh` | `.worktreeinclude` 自動生成 |
 | `PreToolUse` Bash (`gh pr merge*`) | `allow-pr-merge.sh` | merge 先 branch チェック |
+| `PreToolUse` Bash \| Read | `pretool-context-guard.sh` | 20KB 超の構造化ファイル / 100KB 超のファイルの全読みを deny し、`jq`/`gron`/`yq`/`duckdb`/`rga` の代替コマンドを返す |
 | `PostToolUse` 系 | `posttool-secret-mask.sh` | 出力中の secret をマスク |
 | `Stop` | `stop-devflow-telemetry.sh` | dev-flow telemetry の journal flush（失敗時 `~/.claude/logs/stop-devflow-telemetry.log`） |
 

--- a/claude-code/RULES.md
+++ b/claude-code/RULES.md
@@ -28,18 +28,14 @@ Conflict: Safety > Scope > Quality > Speed
 - **No Over-Orchestration**: trivial な単発作業は Workflow 化せず直接ツールを叩く。ultracode でも例外でない
 
 ## Tool Routing
-🟢 コンテキスト節約と精度向上のため、ファイル全読み・テキスト grep の前に専用 CLI で絞る:
-- **コードベース概観** → `tokei`（言語構成・規模。ファイルを読み始める前にまず全体像）
-- **同一コードパターンを3箇所以上書き換える時**（rename・API移行・codemod）→ sed/手編集でなく `ast-grep --pattern … --rewrite …`。コメント・文字列リテラルへの誤爆がなく、全箇所を機械的に網羅できる
-- **grep 結果にコメント・文字列の偽陽性が混ざる検索** → `ast-grep --pattern`（AST ノードのみマッチ）
-- **JSON** → `jq` で必要キーのみ抽出。構造が未知なら `gron <file> | rg <keyword>` でパス発見
-- **YAML/TOML/XML** → `yq` で必要部分のみ抽出
-- **CSV/Parquet/巨大 JSON の集計** → `duckdb -c "SELECT ..."`（Read で全読みしない）
-- **PDF/docx/zip/sqlite 内の検索** → `rga`（ripgrep-all）
+🟢 全読み（20KB 超の構造化ファイル / 100KB 超）は `pretool-context-guard.sh` が deny し `jq`/`gron`/`yq`/`duckdb`/`rga` を提示する。以下は hook が意図を検知できないので自分で選ぶ:
+- **コードベース概観** → `tokei`（読み始める前にまず全体像）
+- **同一パターンを3箇所以上書き換え**（rename・API移行）→ sed でなく `ast-grep --pattern … --rewrite …`（コメント・文字列に誤爆しない）
+- **grep 結果に偽陽性が混ざる検索** → `ast-grep --pattern`（AST ノードのみ）
 - **機械的な文字列置換** → `sd`（sed より事故りにくい）
-- **refactor・フォーマッタ適用後の「挙動不変」確認** → `difft --exit-code old new`（構造変化ゼロ＝フォーマットのみ、を機械判定。目視 diff レビューを省略できる）
+- **フォーマッタ適用後の挙動不変確認** → `difft --exit-code old new`
+- **性能主張の裏取り** → `hyperfine`（体感で速い/遅いを言わない）
 - **リポジトリ全体のコンテキスト化** → repomix（/repo-export skill）
-- **性能主張の裏取り** → `hyperfine`（体感や推測で速い/遅いを言わない）
 
 ## Organization
 - Follow existing project conventions for naming and directory structure

--- a/claude-code/hooks/pretool-context-guard.sh
+++ b/claude-code/hooks/pretool-context-guard.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash|Read) hook: コンテキスト浪費の検知と専用 CLI への誘導
+#
+# 目的:
+#   RULES.md の Tool Routing（jq / yq / duckdb / rga で絞ってから読む）は
+#   「読ませるルール」では発火しなかった（導入 18 日の実測で新 CLI の
+#   使用率は Bash 1000 回あたり 1 回未満、cat/head/tail はむしろ増加）。
+#   判断に頼らず、コンテキストを実際に浪費する瞬間を機械的に検知して
+#   deny + 代替コマンドの提示で確実に発火させる。
+#
+# 検知対象:
+#   1. 構造化ファイル (json/yaml/toml/xml/csv/tsv/parquet) の全読み
+#      - 20KB 超かつ出力が絞られていない cat/Read → jq / yq / duckdb へ誘導
+#   2. 巨大プレーンファイル (100KB 超) の全読み
+#      - cat / limit なし Read → rg で位置特定、sed -n 範囲指定、Read の limit へ誘導
+#   3. バイナリ文書 (pdf/docx/xlsx/pptx/epub/zip/sqlite) への rg/grep
+#      - そもそも失敗するので rga へ誘導
+#
+# fail-open の方針:
+#   これは安全性ではなく効率のためのガードなので、判定できないものは通す。
+#     - ファイルが存在しない / パスが変数・glob → 通す
+#     - パイプやリダイレクトで出力が絞られている (`cat x.json | jq …`) → 通す
+#       (コンテキストに載るのは絞った後の出力なので害がない)
+#     - 閾値以下のサイズ → 通す
+#
+# 出力:
+#   - 検知時: stdout に
+#       {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#         "permissionDecision":"deny",
+#         "permissionDecisionReason":"<理由と代替コマンド>"}}
+#   - 非検知時: stdout 空で exit 0（チェーン通過）
+
+set -euo pipefail
+
+# --- 閾値 ---
+# 20KB ≈ 5k tokens: 構造化ファイルはこのサイズを超えたら抽出すべき
+STRUCTURED_LIMIT=${CONTEXT_GUARD_STRUCTURED_LIMIT:-20480}
+# 100KB ≈ 25k tokens: プレーンテキストでもこれを超える全読みは事故
+PLAIN_LIMIT=${CONTEXT_GUARD_PLAIN_LIMIT:-102400}
+
+INPUT=$(cat)
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [[ -n $CWD && -d $CWD ]]; then
+  cd "$CWD" || true
+fi
+
+emit_deny() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+file_size() {
+  local f="$1"
+  stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0
+}
+
+human_size() {
+  local bytes="$1"
+  echo "$((bytes / 1024))KB"
+}
+
+# 拡張子から種別を返す: structured_json / structured_yaml / tabular / binary_doc / plain
+classify() {
+  local f="$1"
+  local ext="${f##*.}"
+  case "$(echo "$ext" | tr '[:upper:]' '[:lower:]')" in
+    json | jsonl | ndjson) echo "structured_json" ;;
+    yaml | yml | toml | xml) echo "structured_yaml" ;;
+    csv | tsv | parquet) echo "tabular" ;;
+    pdf | docx | xlsx | pptx | epub | zip | sqlite | sqlite3 | db) echo "binary_doc" ;;
+    *) echo "plain" ;;
+  esac
+}
+
+# 種別ごとの代替コマンド提示
+advice_for() {
+  local kind="$1" f="$2"
+  case "$kind" in
+    structured_json)
+      echo "jq で必要キーだけ抽出する: jq '.foo.bar' ${f}  /  構造が未知なら gron ${f} | rg <keyword> でパスを見つけてから jq"
+      ;;
+    structured_yaml)
+      echo "yq で必要部分だけ抽出する: yq '.foo.bar' ${f}"
+      ;;
+    tabular)
+      echo "duckdb で集計・抽出する: duckdb -c \"SELECT … FROM '${f}' LIMIT 20\""
+      ;;
+    binary_doc)
+      echo "rga（ripgrep-all）で中身を検索する: rga <pattern> ${f}"
+      ;;
+    *)
+      echo "rg <pattern> ${f} で該当行を特定し、sed -n 'START,ENDp' ${f} か Read の offset/limit で必要な範囲だけ読む"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Read ツール
+# ---------------------------------------------------------------------------
+if [[ $TOOL == "Read" ]]; then
+  FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+  HAS_LIMIT=$(echo "$INPUT" | jq -r 'if (.tool_input.limit // .tool_input.offset) then "yes" else "no" end')
+
+  [[ -z $FILE || ! -f $FILE ]] && exit 0
+  # 範囲指定済みなら意図通りに絞れている
+  [[ $HAS_LIMIT == "yes" ]] && exit 0
+
+  SIZE=$(file_size "$FILE")
+  KIND=$(classify "$FILE")
+
+  case "$KIND" in
+    structured_json | structured_yaml | tabular)
+      if ((SIZE > STRUCTURED_LIMIT)); then
+        emit_deny "$(human_size "$SIZE") の構造化ファイルを全読みしようとしている: ${FILE}
+コンテキストを浪費するので、必要な部分だけ抽出すること。
+→ $(advice_for "$KIND" "$FILE")
+どうしても全体が必要なら Read に offset/limit を付けて分割して読む。"
+      fi
+      ;;
+    plain)
+      if ((SIZE > PLAIN_LIMIT)); then
+        emit_deny "$(human_size "$SIZE") のファイルを全読みしようとしている: ${FILE}
+コンテキストを浪費するので、必要な範囲だけ読むこと。
+→ $(advice_for "$KIND" "$FILE")"
+      fi
+      ;;
+  esac
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Bash ツール
+# ---------------------------------------------------------------------------
+[[ $TOOL != "Bash" ]] && exit 0
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z $CMD ]] && exit 0
+
+# コマンドを「出力がコンテキストに載るセグメント」へ分解する。
+#   - `;` `&&` `||` で文に分割
+#   - 各文をパイプで分割し、最後の要素だけを残す
+#     (`cat x.json | jq …` の cat は出力が jq に渡るので対象外)
+TERMINAL_SEGMENTS=$(echo "$CMD" | awk '
+{
+  n = split($0, stmts, /\|\||&&|;/)
+  for (i = 1; i <= n; i++) {
+    m = split(stmts[i], parts, /\|/)
+    print parts[m]
+  }
+}')
+
+# セグメントから読み取り対象のファイル引数を抽出する。
+# 先頭コマンドが $1 に一致する場合のみ、オプションでない最初の引数を返す。
+extract_file_arg() {
+  local segment="$1" wanted="$2"
+  echo "$segment" | awk -v want="$wanted" '
+  {
+    # 先頭トークンを探す
+    idx = 0
+    for (i = 1; i <= NF; i++) {
+      tok = $i
+      gsub(/^["'"'"']|["'"'"']$/, "", tok)
+      if (tok == want) { idx = i; break }
+      # 先頭が別コマンドなら対象外（`echo foo` の中の cat 等を拾わない）
+      if (tok !~ /^(sudo|env|command|time)$/) break
+    }
+    if (idx == 0) exit
+    for (i = idx + 1; i <= NF; i++) {
+      tok = $i
+      gsub(/^["'"'"']|["'"'"']$/, "", tok)
+      if (tok ~ /^-/) continue
+      print tok
+      exit
+    }
+  }'
+}
+
+while IFS= read -r SEG; do
+  [[ -z ${SEG// /} ]] && continue
+
+  # リダイレクトで出力がファイルへ向かうなら、コンテキストには載らない
+  if echo "$SEG" | grep -q '>'; then
+    continue
+  fi
+
+  # --- 1) rg/grep をバイナリ文書に向けている ---
+  for GREP_CMD in rg grep egrep; do
+    GREP_TARGET=$(extract_file_arg "$SEG" "$GREP_CMD")
+    # rg/grep の第1引数は pattern なので、拡張子を持つ引数を全部見る
+    if [[ -n $GREP_TARGET ]]; then
+      for TOKEN in $SEG; do
+        TOKEN="${TOKEN%\"}"
+        TOKEN="${TOKEN#\"}"
+        TOKEN="${TOKEN%\'}"
+        TOKEN="${TOKEN#\'}"
+        [[ $TOKEN == -* ]] && continue
+        [[ ! -f $TOKEN ]] && continue
+        if [[ $(classify "$TOKEN") == "binary_doc" ]]; then
+          emit_deny "バイナリ文書に ${GREP_CMD} を向けている: ${TOKEN}
+プレーンテキストではないので取りこぼす。
+→ $(advice_for binary_doc "$TOKEN")"
+        fi
+      done
+    fi
+  done
+
+  # --- 2) cat / head / tail による全読み ---
+  for READ_CMD in cat bat; do
+    TARGET=$(extract_file_arg "$SEG" "$READ_CMD")
+    [[ -z $TARGET || ! -f $TARGET ]] && continue
+
+    SIZE=$(file_size "$TARGET")
+    KIND=$(classify "$TARGET")
+
+    case "$KIND" in
+      binary_doc)
+        emit_deny "バイナリ文書を ${READ_CMD} しようとしている: ${TARGET}
+→ $(advice_for binary_doc "$TARGET")"
+        ;;
+      structured_json | structured_yaml | tabular)
+        if ((SIZE > STRUCTURED_LIMIT)); then
+          emit_deny "$(human_size "$SIZE") の構造化ファイルを ${READ_CMD} で全部コンテキストに載せようとしている: ${TARGET}
+→ $(advice_for "$KIND" "$TARGET")"
+        fi
+        ;;
+      plain)
+        if ((SIZE > PLAIN_LIMIT)); then
+          emit_deny "$(human_size "$SIZE") のファイルを ${READ_CMD} で全部コンテキストに載せようとしている: ${TARGET}
+→ $(advice_for "$KIND" "$TARGET")"
+        fi
+        ;;
+    esac
+  done
+done <<<"$TERMINAL_SEGMENTS"
+
+exit 0

--- a/claude-code/hooks/pretool-context-guard.test.sh
+++ b/claude-code/hooks/pretool-context-guard.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Test suite for pretool-context-guard.sh
+#
+# Usage: bash pretool-context-guard.test.sh
+#
+# Exit 0 on all pass, non-zero otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/pretool-context-guard.sh"
+
+if [[ ! -x ${HOOK} ]]; then
+  echo "FAIL: hook not executable: ${HOOK}" >&2
+  exit 1
+fi
+
+# --- フィクスチャ ---
+FIXTURE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/context-guard-test.XXXXXX")
+cleanup() { rm -rf "$FIXTURE_DIR"; }
+trap cleanup EXIT
+
+# 小さい JSON (< 20KB)
+printf '{"a":1,"b":2}\n' >"${FIXTURE_DIR}/small.json"
+# 大きい JSON (> 20KB)
+{
+  printf '{"items":['
+  for i in $(seq 1 2000); do printf '{"id":%d,"name":"item-%d"},' "$i" "$i"; done
+  printf '{"id":0}]}\n'
+} >"${FIXTURE_DIR}/big.json"
+# 大きい YAML (> 20KB)
+for i in $(seq 1 2000); do printf 'key_%d: value-%d\n' "$i" "$i"; done >"${FIXTURE_DIR}/big.yaml"
+# 大きい CSV (> 20KB)
+for i in $(seq 1 2000); do printf '%d,name-%d,value-%d\n' "$i" "$i" "$i"; done >"${FIXTURE_DIR}/big.csv"
+# 小さい Markdown
+printf '# hello\n' >"${FIXTURE_DIR}/small.md"
+# 巨大 Markdown (> 100KB)
+for i in $(seq 1 4000); do printf 'line %d: the quick brown fox jumps over the lazy dog\n' "$i"; done >"${FIXTURE_DIR}/huge.md"
+# 中くらいの Markdown (20KB < size < 100KB) — plain は 100KB まで通す
+for i in $(seq 1 600); do printf 'line %d: the quick brown fox jumps over the lazy dog\n' "$i"; done >"${FIXTURE_DIR}/medium.md"
+# バイナリ文書（中身は問わない、拡張子で判定する）
+printf '%%PDF-1.4 dummy\n' >"${FIXTURE_DIR}/doc.pdf"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# run_bash <name> <command> <expected: deny|pass>
+run_bash() {
+  local name="$1" cmd="$2" expected="$3"
+  local input output decision
+  input=$(jq -n --arg cmd "$cmd" --arg cwd "$FIXTURE_DIR" \
+    '{tool_name:"Bash", cwd:$cwd, tool_input:{command:$cmd}}')
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+  decision="pass"
+  if [[ -n $output ]]; then
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null || echo "pass")
+  fi
+  assert "$name" "$expected" "$decision" "$cmd"
+}
+
+# run_read <name> <file> <limit: -|N> <expected: deny|pass>
+run_read() {
+  local name="$1" file="$2" limit="$3" expected="$4"
+  local input output decision
+  if [[ $limit == "-" ]]; then
+    input=$(jq -n --arg f "$file" --arg cwd "$FIXTURE_DIR" \
+      '{tool_name:"Read", cwd:$cwd, tool_input:{file_path:$f}}')
+  else
+    input=$(jq -n --arg f "$file" --arg cwd "$FIXTURE_DIR" --argjson l "$limit" \
+      '{tool_name:"Read", cwd:$cwd, tool_input:{file_path:$f, limit:$l}}')
+  fi
+  output=$(echo "$input" | bash "$HOOK" 2>&1 || true)
+  decision="pass"
+  if [[ -n $output ]]; then
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // "pass"' 2>/dev/null || echo "pass")
+  fi
+  assert "$name" "$expected" "$decision" "Read $file"
+}
+
+assert() {
+  local name="$1" expected="$2" got="$3" detail="$4"
+  if [[ $got == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    printf "  \033[32mPASS\033[0m %s\n" "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected=$expected got=$got detail=$detail")
+    printf "  \033[31mFAIL\033[0m %s (expected=%s, got=%s)\n" "$name" "$expected" "$got"
+  fi
+}
+
+echo "=== pretool-context-guard tests ==="
+
+echo "[Positive cases — should deny]"
+run_bash "cat 大きい JSON" "cat ${FIXTURE_DIR}/big.json" "deny"
+run_bash "cat 大きい YAML" "cat ${FIXTURE_DIR}/big.yaml" "deny"
+run_bash "cat 大きい CSV" "cat ${FIXTURE_DIR}/big.csv" "deny"
+run_bash "cat 巨大 Markdown" "cat ${FIXTURE_DIR}/huge.md" "deny"
+run_bash "cat PDF" "cat ${FIXTURE_DIR}/doc.pdf" "deny"
+run_bash "rg を PDF に向ける" "rg pattern ${FIXTURE_DIR}/doc.pdf" "deny"
+run_bash "grep を PDF に向ける" "grep pattern ${FIXTURE_DIR}/doc.pdf" "deny"
+run_bash "パイプ後段の cat も対象" "echo start && cat ${FIXTURE_DIR}/big.json" "deny"
+run_read "Read 大きい JSON (limit なし)" "${FIXTURE_DIR}/big.json" "-" "deny"
+run_read "Read 巨大 Markdown (limit なし)" "${FIXTURE_DIR}/huge.md" "-" "deny"
+
+echo "[Negative cases — should pass]"
+run_bash "cat 小さい JSON" "cat ${FIXTURE_DIR}/small.json" "pass"
+run_bash "cat 小さい Markdown" "cat ${FIXTURE_DIR}/small.md" "pass"
+run_bash "cat 中サイズ Markdown (100KB 未満)" "cat ${FIXTURE_DIR}/medium.md" "pass"
+run_bash "jq に渡す cat" "cat ${FIXTURE_DIR}/big.json | jq '.items[0]'" "pass"
+run_bash "リダイレクトする cat" "cat ${FIXTURE_DIR}/big.json > /dev/null" "pass"
+run_bash "head で絞る" "head -20 ${FIXTURE_DIR}/big.json" "pass"
+run_bash "jq で直接絞る" "jq '.items[0]' ${FIXTURE_DIR}/big.json" "pass"
+run_bash "rg を通常ファイルに向ける" "rg pattern ${FIXTURE_DIR}/huge.md" "pass"
+run_bash "存在しないファイル" "cat ${FIXTURE_DIR}/nonexistent.json" "pass"
+run_bash "変数展開されたパス" 'cat "$SOME_VAR/big.json"' "pass"
+run_bash "cat という文字列を含む別コマンド" "echo cat ${FIXTURE_DIR}/big.json" "pass"
+run_bash "git 操作" "git status --short" "pass"
+run_read "Read 大きい JSON (limit あり)" "${FIXTURE_DIR}/big.json" "50" "pass"
+run_read "Read 小さい JSON" "${FIXTURE_DIR}/small.json" "-" "pass"
+run_read "Read 中サイズ Markdown" "${FIXTURE_DIR}/medium.md" "-" "pass"
+
+echo
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if ((FAIL > 0)); then
+  printf '\nFailures:\n'
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi

--- a/claude-code/settings.json
+++ b/claude-code/settings.json
@@ -200,6 +200,17 @@
           }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "bash \"$HOME/.claude/hooks/pretool-context-guard.sh\"",
+            "statusMessage": "コンテキスト浪費チェック中...",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|Read"
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## 背景

RULES.md の Tool Routing 節（2026-07-15 導入, 9a94e30）が実際に機能しているかをセッションログ全 6,013 ファイル / 851MB から実測した。導入前後 18 日ずつ（6/27–7/14 vs 7/16–8/2）を Bash 1,000 回あたりの出現率で正規化して比較した結果:

| CLI | before | after | 実件数 |
|---|---|---|---|
| jq | 18.9 | 40.5 | 1429 |
| sd | 0 | 1.59 | 56 |
| tokei | 0 | 1.30 | 46 |
| yq | 0 | 0.88 | 31 |
| ast-grep | 0 | 0.34 | 12（実利用 4、`--rewrite` 2） |
| hyperfine / difft / duckdb / gron / rga | 0 | 0.2〜0.3 | 各 7〜10 |

置き換え対象だった側:

| | before | after |
|---|---|---|
| rg/grep | 275 | 251 (-9%) |
| cat | 86 | 97 (+12%) |
| head | 223 | 235 (+5%) |
| tail | 126 | 139 (+10%) |

**新 CLI は「代替」ではなく「純増」に留まり、全読み系はむしろ増えていた。** 新 CLI の日次出現は 7/27（ブログ執筆時の動作検証日）にピークを作った後、7/31 以降ほぼゼロで定着していない。

一方で節自体は 1,512B（概ね 700〜900 トークン）を全セッション・全サブエージェントのコンテキストに毎回載せており、収支はマイナス寄りだった。

## 変更内容

読ませるルールをやめ、コンテキストを実際に浪費する瞬間を PreToolUse hook で機械的に検知する。

**`claude-code/hooks/pretool-context-guard.sh`** (`matcher: Bash|Read`)

| 検知 | 反応 |
|---|---|
| 20KB 超の構造化ファイル (json/jsonl/yaml/toml/xml/csv/tsv/parquet) の `cat` / limit なし `Read` | deny + `jq` / `gron` / `yq` / `duckdb` の具体的コマンド |
| 100KB 超のファイルの全読み | deny + `rg` で位置特定 → `sed -n` 範囲指定 or `Read` の offset/limit |
| バイナリ文書 (pdf/docx/xlsx/pptx/epub/zip/sqlite) への `rg`/`grep`/`cat` | deny + `rga` |

閾値は環境変数 `CONTEXT_GUARD_STRUCTURED_LIMIT` / `CONTEXT_GUARD_PLAIN_LIMIT` で上書きできる。

### fail-open の方針

安全性ではなく効率のためのガードなので、判定できないものは通す:

- ファイルが存在しない / パスが変数・glob
- パイプやリダイレクトで出力が絞られている（`cat x.json | jq …` はコンテキストに載るのが絞った後なので害がない）
- 閾値以下のサイズ

### RULES.md の圧縮

hook がカバーする範囲（jq/gron/yq/duckdb/rga）を節から削除し、hook が意図を検知できないもの（tokei / ast-grep / sd / difft / hyperfine / repomix）だけ残した。**1,512B → 965B (-36%)**。

## テスト

`claude-code/hooks/pretool-context-guard.test.sh` — 25 件全パス。うち 15 件は偽陽性を防ぐネガティブケース（パイプ後段の cat、リダイレクト、変数展開されたパス、`echo cat …`、閾値未満、limit 付き Read など）。

```
=== Results: 25 passed, 0 failed ===
```

実ファイル（199KB の `.jsonl`）での発火も確認済み。

## 未検証（sandbox 制約）

- `shellcheck`: sandbox から nix daemon socket に接続できず未実行。`bash -n` の構文チェックは通過済み
- `nix fmt` / `nix flake check`: 同上
- **適用は人間の作業**: `nix run .#update` で `~/.claude/hooks/` への symlink が張られるまで hook は有効にならない

## 補足

hook 化できないもの（ast-grep の「3箇所以上書き換える意図」、difft、hyperfine）は事前検知が原理的に困難なため、引き続き RULES.md 側に残している。これらが次も使われないようなら、節から削って完全に諦める判断もありうる。