### PR TITLE
fix: 🐛 mise overlay に cmake を追加してビルド失敗を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,9 +77,13 @@
             # mise の checkPhase は Nix サンドボックスが setuid bit 付与を許可しないため
             # oci::layer::tests::preserve_metadata_dir_layer_keeps_special_permission_bits が失敗する。
             # nixpkgs 側でこのテストが skip されたら削除可。
+            # cmake は nixpkgs 側で nativeCheckInputs にあるため doCheck = false で PATH から外れるが、
+            # mise 2026.7.17 で追加された libz-ng-sys の build.rs が buildPhase で cmake を要求する。
+            # nativeBuildInputs に明示的に足さないと "is `cmake` not installed?" でビルドが落ちる。
             (_final: prev: {
-              mise = prev.mise.overrideAttrs (_: {
+              mise = prev.mise.overrideAttrs (old: {
                 doCheck = false;
+                nativeBuildInputs = old.nativeBuildInputs ++ [ prev.cmake ];
               });
             })
             # ollama 0.30.5 は macOS arm64 で MLX backend がデフォルト有効になり、


### PR DESCRIPTION
## 問題

`nix run .#update naramotoyuuji` で flake.lock 更新後の検証ビルドが失敗し、ロールバックされる。

```
error: Cannot build '/nix/store/...-mise-2026.7.17.drv'.
> thread 'main' panicked at .../cmake-0.1.58/src/lib.rs:1132:5:
> failed to execute command: No such file or directory (os error 2)
> is `cmake` not installed?
```

mise の失敗が `home-manager-path` / `home-manager-generation` など 6 つの derivation に連鎖し、flake.lock がロールバックされていた。

## 原因

- nixpkgs の mise は `nativeBuildInputs = [ installShellFiles pkg-config ]` のみで、**`cmake` は `nativeCheckInputs` 側**にある
- `nativeCheckInputs` は `doCheck = true` のときだけ build 環境の PATH に載る。upstream のビルドはこれで buildPhase でも cmake が使えている
- 本 repo の overlay は checkPhase の setuid テスト回避のため `doCheck = false` にしており、その副作用で **cmake が PATH から消える**
- mise **2026.7.17** で新たに `libz-ng-sys`（zlib-ng）依存が入り、その `build.rs` が **buildPhase で cmake を要求**するようになった（2026.7.10 では不要だったため今回顕在化）

## 修正

overlay で `nativeBuildInputs` に `cmake` を明示追加する。`doCheck = false` は維持（新 rev の `checkFlags` にも `oci::layer::tests::preserve_metadata_dir_layer_keeps_special_permission_bits` の skip は入っていないため、引き続き必要）。

## 検証

- `nix-instantiate --parse flake.nix` → OK
- ⚠️ **`nix fmt` / `nix flake check` / `nix run .#update` は未実行**（agent サンドボックスから nix daemon socket に接続できないため）。apply は人間側での実行をお願いします