### PR TITLE
✨ fix(claude-code): Stop hook が trust_evalseal_missing_reason を journal へ転送していない（skills#471 Phase 1 の送り側） (#154)

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -80,6 +80,7 @@ for f in "${PENDING_DIR}"/*.json; do
   trust_run_id=""
   trust_receipts_json=""
   trust_surfaceproof_json=""
+  trust_evalseal_missing_reason=""
   error_category=""
   error_msg=""
   vdelta_verdicts_json=""
@@ -115,6 +116,7 @@ for f in "${PENDING_DIR}"/*.json; do
     trust_run_id: .telemetry.trust_run_id,
     trust_receipts: .telemetry.trust_receipts,
     trust_surfaceproof: .telemetry.trust_surfaceproof_shadow,
+    trust_evalseal_missing_reason: .telemetry.trust_evalseal_missing_reason,
     vdelta_verdicts: .telemetry.vdelta_verdicts,
     vdelta_fail_open: .telemetry.vdelta_fail_open,
     redgreen_deny: .telemetry.redgreen_deny,
@@ -167,6 +169,7 @@ for f in "${PENDING_DIR}"/*.json; do
   trust_run_id=$(echo "$parsed" | jq -r '.trust_run_id // empty')
   trust_receipts_json=$(echo "$parsed" | jq -c '.trust_receipts // empty')
   trust_surfaceproof_json=$(echo "$parsed" | jq -c '.trust_surfaceproof // empty')
+  trust_evalseal_missing_reason=$(echo "$parsed" | jq -r '.trust_evalseal_missing_reason // empty')
   vdelta_verdicts_json=$(echo "$parsed" | jq -c '.vdelta_verdicts // empty')
   vdelta_fail_open=$(echo "$parsed" | jq -r '.vdelta_fail_open // empty')
   redgreen_deny_json=$(echo "$parsed" | jq -c '.redgreen_deny // empty')
@@ -278,6 +281,18 @@ for f in "${PENDING_DIR}"/*.json; do
       printf '%s %s trust-key-dropped: trust_surfaceproof_shadow (journal.sh closed-enum 契約を満たさない)\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
     fi
+  fi
+  if [[ -n $trust_evalseal_missing_reason && $trust_evalseal_missing_reason != "null" ]]; then
+    case "$trust_evalseal_missing_reason" in
+    eval_skipped | agent_throw | agent_null | seal_error | mode_off | unknown)
+      cmd_args+=(--trust-evalseal-missing-reason "$trust_evalseal_missing_reason")
+      ;;
+    *)
+      mkdir -p "$(dirname "$LOG_FILE")"
+      printf '%s %s trust-key-dropped: trust_evalseal_missing_reason (journal.sh closed-enum 契約を満たさない)\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
+      ;;
+    esac
   fi
 
   # --- telemetry 8-key forwarding (issue #143 / #430) ---

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -1678,6 +1678,139 @@ make_full_telemetry_handoff() {
 }
 
 # --------------------------------------------------------------------------
+# Test T-A: valid trust_evalseal_missing_reason → --trust-evalseal-missing-reason
+#           is forwarded to journal.sh
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/evalseal.json" "$stub" \
+    '.telemetry += {trust_evalseal_missing_reason: "agent_throw"}'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-evalseal-missing-reason agent_throw"; then
+    pass "trust_evalseal_missing_reason_forwarded"
+  else
+    fail "trust_evalseal_missing_reason_forwarded" "expected --trust-evalseal-missing-reason agent_throw. got: ${captured}"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/evalseal.json" ]]; then
+    pass "trust_evalseal_missing_reason_pending_removed"
+  else
+    fail "trust_evalseal_missing_reason_pending_removed" "pending file should be removed after success"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-B: trust_evalseal_missing_reason with a closed-enum 契約違反の値
+#           → 当該フラグのみ drop、base entry は記録される、drop はログされる
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/badreason.json" "$stub" \
+    '.telemetry += {trust_evalseal_missing_reason: "totally_bogus"}'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-evalseal-missing-reason"; then
+    fail "bad_evalseal_missing_reason_dropped" "invalid --trust-evalseal-missing-reason must not be forwarded. got: ${captured}"
+  else
+    pass "bad_evalseal_missing_reason_dropped"
+  fi
+  if echo "$captured" | grep -q -- "--merge-tier REVIEW"; then
+    pass "bad_evalseal_missing_reason_base_entry_preserved"
+  else
+    fail "bad_evalseal_missing_reason_base_entry_preserved" "base telemetry must still be logged. got: ${captured}"
+  fi
+  if grep -q "trust-key-dropped: trust_evalseal_missing_reason" \
+    "${tmpd}/.claude/logs/stop-devflow-telemetry.log" 2>/dev/null; then
+    pass "bad_evalseal_missing_reason_logged"
+  else
+    fail "bad_evalseal_missing_reason_logged" "drop must be recorded in the log (silent drop 禁止)"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/badreason.json" ]]; then
+    pass "bad_evalseal_missing_reason_pending_removed"
+  else
+    fail "bad_evalseal_missing_reason_pending_removed" "pending file must not be stuck on trust-key drop"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-C: trust_evalseal_missing_reason absent → no such flag at all
+#           (空値を渡さない)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/noreason.json" "$stub" '.'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-evalseal-missing-reason"; then
+    fail "trust_evalseal_missing_reason_absent_no_flag" "no --trust-evalseal-missing-reason flag expected. got: ${captured}"
+  else
+    pass "trust_evalseal_missing_reason_absent_no_flag"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-D (integration): 実 journal.sh が存在する環境では、
+#          trust_evalseal_missing_reason が実際に journal entry の
+#          telemetry へ到達することを確認する。未配置環境では skip。
+# --------------------------------------------------------------------------
+{
+  REAL_JOURNAL="${HOME}/ghq/github.com/it-all-playpark/skills/skill-retrospective/scripts/journal.sh"
+  if [[ ! -x $REAL_JOURNAL ]]; then
+    echo "  (skip: real journal.sh not found — integration test skipped)"
+  else
+    tmpd=$(make_tmpdir)
+    mkdir -p "${tmpd}/journal/pending"
+
+    make_trust_handoff "${tmpd}/journal/pending/e2ereason.json" "$REAL_JOURNAL" \
+      '.telemetry += {trust_evalseal_missing_reason: "seal_error"}'
+
+    run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+    entry=$(ls "${tmpd}/journal"/*.json 2>/dev/null | head -1 || true)
+    if [[ -z $entry ]]; then
+      fail "integration_evalseal_missing_reason_entry_written" "no journal entry created. hook output: ${RUN_OUT}"
+    else
+      pass "integration_evalseal_missing_reason_entry_written"
+      if [[ $(jq -r '.telemetry.trust_evalseal_missing_reason' "$entry") == "seal_error" ]] &&
+        [[ $(jq -r '.telemetry.merge_tier' "$entry") == "REVIEW" ]]; then
+        pass "integration_evalseal_missing_reason_persisted"
+      else
+        fail "integration_evalseal_missing_reason_persisted" "trust_evalseal_missing_reason missing/altered in entry: $(jq -c '.telemetry' "$entry")"
+      fi
+    fi
+
+    rm -rf "$tmpd"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 概要
Closes #154

- `stop-devflow-telemetry.sh` に `trust_evalseal_missing_reason` telemetry の抽出・検証・転送を追加
- `journal.sh` 側の closed-enum 契約（`eval_skipped|agent_throw|agent_null|seal_error|mode_off|unknown`）を hook 側で先に検証し、合致する値のみ `--trust-evalseal-missing-reason` として転送
- 契約外の値は当該フラグのみ drop し、`trust-key-dropped:` としてログへ記録（silent drop はしない）

## 動機

skills#471 で EvalSeal receipt 欠落の理由を closed enum で記録する受け側（`journal.sh`）が実装済みだったが、送り側である本 repo の Stop hook が未配線だった。既存 trust キー（`trust_run_id` / `trust_receipts` / `trust_surfaceproof_shadow`）と同様、`trust_evalseal_missing_reason` も転送しないと理由分布が恒久的に `unrecorded` のままになり、EvalSeal receipt が出ない原因（agent 拒否 / script 例外 / Evaluate skip 等）を実データで判別できない。

dotfiles#133 と同型の「受け側先行・送り側欠落」の構図であり、無検査転送すると `journal.sh` が exit 1 して entry 全体が pending へ差し戻される既知の失敗モードがあるため、hook 側で先に closed enum を検証する fail-open 方式を踏襲した。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `claude-code/hooks/stop-devflow-telemetry.sh` | `trust_evalseal_missing_reason` の変数宣言・jq projection・値取り出し・closed-enum 検証・`cmd_args` への追加を実装 |
| `claude-code/hooks/stop-devflow-telemetry.test.sh` | 正常転送(T-A)・enum 違反時の drop とログ(T-B)・キー不在時に未転送(T-C)・実 `journal.sh` との結合(T-D) の4テストケースを追加 |

## テスト計画

- [x] `claude-code/hooks/stop-devflow-telemetry.test.sh` を実行し追加テスト・既存テストが全て green であることを確認
- [ ] merge 後の実 dev-flow run で skills 側 `trust-receipts-report.sh --slo --window 30d` の `reason_distribution` に `unrecorded` 以外の値が現れることを確認（Phase 3、issue #154 参照）
