### PR TITLE
feat(hooks): trust_effectdelta_pr_missing_reason telemetry を journal.sh へ転送（skills#476 Phase 1 の送り側）

### DIFF
--- a/claude-code/hooks/stop-devflow-telemetry.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.sh
@@ -81,6 +81,7 @@ for f in "${PENDING_DIR}"/*.json; do
   trust_receipts_json=""
   trust_surfaceproof_json=""
   trust_evalseal_missing_reason=""
+  trust_effectdelta_pr_missing_reason=""
   error_category=""
   error_msg=""
   vdelta_verdicts_json=""
@@ -117,6 +118,7 @@ for f in "${PENDING_DIR}"/*.json; do
     trust_receipts: .telemetry.trust_receipts,
     trust_surfaceproof: .telemetry.trust_surfaceproof_shadow,
     trust_evalseal_missing_reason: .telemetry.trust_evalseal_missing_reason,
+    trust_effectdelta_pr_missing_reason: .telemetry.trust_effectdelta_pr_missing_reason,
     vdelta_verdicts: .telemetry.vdelta_verdicts,
     vdelta_fail_open: .telemetry.vdelta_fail_open,
     redgreen_deny: .telemetry.redgreen_deny,
@@ -170,6 +172,7 @@ for f in "${PENDING_DIR}"/*.json; do
   trust_receipts_json=$(echo "$parsed" | jq -c '.trust_receipts // empty')
   trust_surfaceproof_json=$(echo "$parsed" | jq -c '.trust_surfaceproof // empty')
   trust_evalseal_missing_reason=$(echo "$parsed" | jq -r '.trust_evalseal_missing_reason // empty')
+  trust_effectdelta_pr_missing_reason=$(echo "$parsed" | jq -r '.trust_effectdelta_pr_missing_reason // empty')
   vdelta_verdicts_json=$(echo "$parsed" | jq -c '.vdelta_verdicts // empty')
   vdelta_fail_open=$(echo "$parsed" | jq -r '.vdelta_fail_open // empty')
   redgreen_deny_json=$(echo "$parsed" | jq -c '.redgreen_deny // empty')
@@ -290,6 +293,23 @@ for f in "${PENDING_DIR}"/*.json; do
     *)
       mkdir -p "$(dirname "$LOG_FILE")"
       printf '%s %s trust-key-dropped: trust_evalseal_missing_reason (journal.sh closed-enum 契約を満たさない)\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
+      ;;
+    esac
+  fi
+  # EffectDelta PR stage receipt の欠落理由（skills#476 Phase 1 の送り側）。enum は
+  # journal.sh の --trust-effectdelta-pr-missing-reason と一致させること。EvalSeal 側とは
+  # 独立定義であり（skills#476 D-3）、値集合が違うので case を共有しない。
+  # journal.sh は out-of-enum・空文字の両方で die_json する（fail-closed）ため、
+  # 契約を満たさない値は必ず送り側で drop する（entry ごと失わないため）。
+  if [[ -n $trust_effectdelta_pr_missing_reason && $trust_effectdelta_pr_missing_reason != "null" ]]; then
+    case "$trust_effectdelta_pr_missing_reason" in
+    agent_throw | agent_null | mode_off | gh_failed | script_error | agent_error | schema_invalid | unknown)
+      cmd_args+=(--trust-effectdelta-pr-missing-reason "$trust_effectdelta_pr_missing_reason")
+      ;;
+    *)
+      mkdir -p "$(dirname "$LOG_FILE")"
+      printf '%s %s trust-key-dropped: trust_effectdelta_pr_missing_reason (journal.sh closed-enum 契約を満たさない)\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$f")" >>"$LOG_FILE"
       ;;
     esac

--- a/claude-code/hooks/stop-devflow-telemetry.test.sh
+++ b/claude-code/hooks/stop-devflow-telemetry.test.sh
@@ -1811,6 +1811,173 @@ make_full_telemetry_handoff() {
 }
 
 # --------------------------------------------------------------------------
+# Test T-E: valid trust_effectdelta_pr_missing_reason
+#           → --trust-effectdelta-pr-missing-reason is forwarded to journal.sh
+#           (issue #156 AC-1 / skills#476 Phase 1 送り側)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/effectdelta.json" "$stub" \
+    '.telemetry += {trust_effectdelta_pr_missing_reason: "gh_failed"}'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-effectdelta-pr-missing-reason gh_failed"; then
+    pass "trust_effectdelta_pr_missing_reason_forwarded"
+  else
+    fail "trust_effectdelta_pr_missing_reason_forwarded" "expected --trust-effectdelta-pr-missing-reason gh_failed. got: ${captured}"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/effectdelta.json" ]]; then
+    pass "trust_effectdelta_pr_missing_reason_pending_removed"
+  else
+    fail "trust_effectdelta_pr_missing_reason_pending_removed" "pending file should be removed after success"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-E2: closed enum の全 8 値が転送される（EvalSeal と値集合が違うので
+#            取り違えると silent に落ちる。全値を固定する — issue #156 AC-1）
+# --------------------------------------------------------------------------
+{
+  for reason in agent_throw agent_null mode_off gh_failed script_error agent_error schema_invalid unknown; do
+    tmpd=$(make_tmpdir)
+    mkdir -p "${tmpd}/journal/pending"
+    capture="${tmpd}/capture.txt"
+    stub="${tmpd}/journal.sh"
+    make_stub_journal "$stub" "$capture" 0
+
+    make_trust_handoff "${tmpd}/journal/pending/ed-${reason}.json" "$stub" \
+      ".telemetry += {trust_effectdelta_pr_missing_reason: \"${reason}\"}"
+
+    run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+    captured=$(cat "$capture" 2>/dev/null || echo "")
+    if echo "$captured" | grep -q -- "--trust-effectdelta-pr-missing-reason ${reason}"; then
+      pass "trust_effectdelta_pr_missing_reason_enum_${reason}"
+    else
+      fail "trust_effectdelta_pr_missing_reason_enum_${reason}" "enum value ${reason} must be forwarded. got: ${captured}"
+    fi
+
+    rm -rf "$tmpd"
+  done
+}
+
+# --------------------------------------------------------------------------
+# Test T-F: trust_effectdelta_pr_missing_reason に closed-enum 契約違反の値
+#           → 当該フラグのみ drop、base entry は記録される、drop はログされる
+#           (issue #156 AC-2 / AC-3)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  # seal_error は EvalSeal 側 enum の値であり EffectDelta 側には無い。
+  # case を共有すると誤って通るので、この値で分離を固定する。
+  make_trust_handoff "${tmpd}/journal/pending/badeffectdelta.json" "$stub" \
+    '.telemetry += {trust_effectdelta_pr_missing_reason: "seal_error"}'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-effectdelta-pr-missing-reason"; then
+    fail "bad_effectdelta_pr_missing_reason_dropped" "invalid --trust-effectdelta-pr-missing-reason must not be forwarded. got: ${captured}"
+  else
+    pass "bad_effectdelta_pr_missing_reason_dropped"
+  fi
+  if echo "$captured" | grep -q -- "--merge-tier REVIEW"; then
+    pass "bad_effectdelta_pr_missing_reason_base_entry_preserved"
+  else
+    fail "bad_effectdelta_pr_missing_reason_base_entry_preserved" "base telemetry must still be logged. got: ${captured}"
+  fi
+  if grep -q "trust-key-dropped: trust_effectdelta_pr_missing_reason" \
+    "${tmpd}/.claude/logs/stop-devflow-telemetry.log" 2>/dev/null; then
+    pass "bad_effectdelta_pr_missing_reason_logged"
+  else
+    fail "bad_effectdelta_pr_missing_reason_logged" "drop must be recorded in the log (silent drop 禁止)"
+  fi
+  if [[ ! -f "${tmpd}/journal/pending/badeffectdelta.json" ]]; then
+    pass "bad_effectdelta_pr_missing_reason_pending_removed"
+  else
+    fail "bad_effectdelta_pr_missing_reason_pending_removed" "pending file must not be stuck on trust-key drop"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-G: trust_effectdelta_pr_missing_reason absent → no such flag at all
+#           (空値を渡さない。journal.sh は空文字でも die_json するため
+#            entry ごと失う — issue #156 AC-4)
+# --------------------------------------------------------------------------
+{
+  tmpd=$(make_tmpdir)
+  mkdir -p "${tmpd}/journal/pending"
+  capture="${tmpd}/capture.txt"
+  stub="${tmpd}/journal.sh"
+  make_stub_journal "$stub" "$capture" 0
+
+  make_trust_handoff "${tmpd}/journal/pending/noeffectdelta.json" "$stub" '.'
+
+  run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+  captured=$(cat "$capture" 2>/dev/null || echo "")
+  if echo "$captured" | grep -q -- "--trust-effectdelta-pr-missing-reason"; then
+    fail "trust_effectdelta_pr_missing_reason_absent_no_flag" "no --trust-effectdelta-pr-missing-reason flag expected. got: ${captured}"
+  else
+    pass "trust_effectdelta_pr_missing_reason_absent_no_flag"
+  fi
+
+  rm -rf "$tmpd"
+}
+
+# --------------------------------------------------------------------------
+# Test T-H (integration): 実 journal.sh が存在する環境では、
+#          trust_effectdelta_pr_missing_reason が実際に journal entry の
+#          telemetry へ到達することを確認する。未配置環境では skip。
+#          (issue #156 AC-5)
+# --------------------------------------------------------------------------
+{
+  REAL_JOURNAL="${HOME}/ghq/github.com/it-all-playpark/skills/skill-retrospective/scripts/journal.sh"
+  if [[ ! -x $REAL_JOURNAL ]]; then
+    echo "  (skip: real journal.sh not found — integration test skipped)"
+  else
+    tmpd=$(make_tmpdir)
+    mkdir -p "${tmpd}/journal/pending"
+
+    make_trust_handoff "${tmpd}/journal/pending/e2eeffectdelta.json" "$REAL_JOURNAL" \
+      '.telemetry += {trust_effectdelta_pr_missing_reason: "gh_failed"}'
+
+    run_hook "CLAUDE_JOURNAL_DIR=${tmpd}/journal" "HOME=${tmpd}"
+
+    entry=$(ls "${tmpd}/journal"/*.json 2>/dev/null | head -1 || true)
+    if [[ -z $entry ]]; then
+      fail "integration_effectdelta_pr_missing_reason_entry_written" "no journal entry created. hook output: ${RUN_OUT}"
+    else
+      pass "integration_effectdelta_pr_missing_reason_entry_written"
+      if [[ $(jq -r '.telemetry.trust_effectdelta_pr_missing_reason' "$entry") == "gh_failed" ]] &&
+        [[ $(jq -r '.telemetry.merge_tier' "$entry") == "REVIEW" ]]; then
+        pass "integration_effectdelta_pr_missing_reason_persisted"
+      else
+        fail "integration_effectdelta_pr_missing_reason_persisted" "trust_effectdelta_pr_missing_reason missing/altered in entry: $(jq -c '.telemetry' "$entry")"
+      fi
+    fi
+
+    rm -rf "$tmpd"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #156

## 何を直したか

skills#476 Phase 1（EffectDelta の PR stage receipt 欠落理由を closed enum で記録する）は
**受け側だけが merge** されており、送り側である本 hook が当該キーを転送していなかった。

- skills 側（merge 済み・PR it-all-playpark/skills#478）: `dev-flow.js` が
  `trust_effectdelta_pr_missing_reason` を handoff へ出力、`journal.sh` が
  `--trust-effectdelta-pr-missing-reason` を closed enum で受理、`trust-receipts-report.sh` が分布を出力
- 本 repo（未実装だった）: `stop-devflow-telemetry.sh` の jq projection は固定キー列挙で、
  当該キーを含まないため silent に落ちていた

結果、skills#476 Phase 1 の完了条件「新規 run で理由コードが journal telemetry へ到達し、
report に分布が出る」が未達のままだった。分布が出ないと skills#476 Phase 2（分布に基づく
root cause 修正）が開始できず、epic skills#390 AC-8 も観測できない。

## 変更内容

#154（EvalSeal の同型 issue）の実装を踏襲し、4 箇所を追加した（hook 本体 +20 行）。

1. 変数初期化 `trust_effectdelta_pr_missing_reason=""`
2. jq projection へ 1 行
3. `parsed` からの変数抽出 1 行
4. closed enum 検証 + `--trust-effectdelta-pr-missing-reason` 付与ブロック

enum は `journal.sh` 側と一致させた 8 値:

```
agent_throw | agent_null | mode_off | gh_failed | script_error | agent_error | schema_invalid | unknown
```

EvalSeal 側（`eval_skipped|agent_throw|agent_null|seal_error|mode_off|unknown`）とは**値集合が
異なる独立定義**（skills#476 D-3）なので `case` は共有していない。

`journal.sh` は out-of-enum と空文字の両方で `die_json` する fail-closed 契約のため、
契約を満たさない値は必ず送り側で drop し `trust-key-dropped` としてログへ残す。
base entry の記録は必ず成功させる（fail-open。#133 で「送り側が受け側を追い越すと entry ごと
pending へ差し戻され基本 telemetry を失う」ことが実証済み。本 PR は受け側先行なので該当しない）。

## テスト

`claude-code/hooks/stop-devflow-telemetry.test.sh` に 4 群（23 assertion）追加。

| Test | 内容 | AC |
|---|---|---|
| T-E | 有効値が `--trust-effectdelta-pr-missing-reason` として転送される | AC-1 |
| T-E2 | closed enum の**全 8 値**が転送される（EvalSeal と値集合が違うため取り違えを固定） | AC-1 |
| T-F | 契約違反値は flag のみ drop・base entry 保持・drop をログ記録 | AC-2 / AC-3 |
| T-G | キー不在時は flag 自体が付かない（空文字を渡すと journal.sh が die_json するため） | AC-4 |
| T-H | 実 `journal.sh` を使った E2E で journal entry の telemetry へ到達 | AC-5 |

T-F は EvalSeal 側 enum の値 `seal_error` を投入している。`case` を共有すると誤って通るため、
enum の分離をテストで固定している。

### 実行結果

```
=== Results: 152 passed, 0 failed ===
```

redgreen 検証: 変更前の hook（`origin/main`）に対して新規テストを実行すると **11 件 fail**、
変更後は 0 fail。テストが実際に欠陥を捕まえていることを確認済み。

## 検証済み AC

- [x] AC-1: 有効値が journal.sh へ渡る（全 8 enum 値で確認）
- [x] AC-2: enum 外の値は drop され `trust-key-dropped: trust_effectdelta_pr_missing_reason` がログに出る
- [x] AC-3: enum 違反時も entry 自体は journal へ到達する（fail-open）
- [x] AC-4: キー不在時は flag 自体が付かない
- [x] AC-5: E2E で `.telemetry.trust_effectdelta_pr_missing_reason` に値が入る
- [x] AC-6: 既存テスト含め全 green（152 passed / 0 failed）

## 影響範囲

既存 trust キー（`trust_run_id` / `trust_receipts` / `trust_surfaceproof` /
`trust_evalseal_missing_reason`）と 8-key telemetry の挙動は不変。追加は純粋な新規キー 1 本のみ。

## merge 後にやること

この PR が merge されると理由コードが journal へ蓄積され始める。数 run 溜まったら
`bash dev-flow-doctor/scripts/trust-receipts-report.sh --slo --window 30d` で PR stage の
理由分布を確認し、skills#476 Phase 2 のスコープを決める（分布を見る前の決め打ち修正は
skills#476 が明示的にリスクとして挙げている）。
